### PR TITLE
A solution for the first homework (hwdetect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,8 @@ GlobalLogic Kharkiv, 2020
 
 This repository is aimed for sharing our exercises and your solutions in scope of the course.
 
+Homeworks:
+- hwdetect - detect attached hardware using user level script file
+
+
 Please refer to wiki for details.

--- a/hwdetect/README.md
+++ b/hwdetect/README.md
@@ -1,0 +1,10 @@
+# Home work hot plugged hardware detector
+
+Create the script 'hwdetect.sh' which detects connected hardware.
+For monitor hardware from user level please use /dev folder,
+output from lsusb and i2detect (optional).
+Most interesting devices are:
+ - USB to TTL convertors,
+ - flash drives,
+ - SD cards,
+ - i2c devices.

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -4,7 +4,8 @@ check_usb_to_ttl() {
 	usb_to_ttl=$(ls /dev | grep -E "^ttyUSB[0-9]+$")
 	if [ -n "$usb_to_ttl" ];
 	then
-		echo "A USB to TTL convertor is connected."
+		echo "A USB to TTL convertor is connected:"
+		echo "${usb_to_ttl}"
 	fi
 }
 

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+check_usb_to_ttl() {
+	usb_to_ttl=$(ls /dev | grep -E "^ttyUSB[0-9]+$")
+	if [ -n "$usb_to_ttl" ];
+	then
+		echo "A USB to TTL convertor is connected."
+	fi
+}
+
+check_usb_to_ttl
+exit 0

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -18,6 +18,14 @@ check_flash_drives() {
 	done
 }
 
+check_sd_card() {
+	if [ -n "$(ls /dev | grep -E "^mmcblk[0-9]+$")" ];
+	then
+		echo "An SD card is connected."
+	fi
+}
+
 check_usb_to_ttl
 check_flash_drives
+check_sd_card
 exit 0

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -25,7 +25,19 @@ check_sd_card() {
 	fi
 }
 
+check_i2c_devices() {
+	for ((i=1; i<=$(i2cdetect -l | wc -l); i++));
+	do
+		i2c_bus=$(i2cdetect -y ${i} | awk '{if (NR!=1) {print}}' | awk '{$1=""}1')
+		if [ -n "$(echo $i2c_bus | grep '[0-9]')" ];
+		then
+			echo "An i2c device is connected"
+		fi
+	done
+}
+
 check_usb_to_ttl
 check_flash_drives
 check_sd_card
+check_i2c_devices
 exit 0

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -13,7 +13,7 @@ check_flash_drives() {
 	do
 		if [ -n "$(udevadm info --query=all --name=${l} | grep 'ID_BUS=usb')" ];
 		then
-			echo "A USB flash drive is connected."
+			echo "A USB flash drive is connected: ${l}"
 		fi
 	done
 }

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -9,7 +9,7 @@ check_usb_to_ttl() {
 }
 
 check_flash_drives() {
-	for l in "$(ls /dev/sd[a-z])";
+	for l in $(ls /dev/sd[a-z]);
 	do
 		if [ -n "$(udevadm info --query=all --name=${l} | grep 'ID_BUS=usb')" ];
 		then

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -8,5 +8,16 @@ check_usb_to_ttl() {
 	fi
 }
 
+check_flash_drives() {
+	for l in "$(ls /dev/sd[a-z])";
+	do
+		if [ -n "$(udevadm info --query=all --name=${l} | grep 'ID_BUS=usb')" ];
+		then
+			echo "A USB flash drive is connected."
+		fi
+	done
+}
+
 check_usb_to_ttl
+check_flash_drives
 exit 0

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -20,9 +20,11 @@ check_flash_drives() {
 }
 
 check_sd_card() {
-	if [ -n "$(ls /dev | grep -E "^mmcblk[0-9]+$")" ];
+	sd_card=$(ls /dev | grep -E "^mmcblk[0-9]+$")
+	if [ -n "$sd_card" ];
 	then
-		echo "An SD card is connected."
+		echo "An SD card is connected:"
+		echo "${sd_card}"
 	fi
 }
 

--- a/hwdetect/hwdetect.sh
+++ b/hwdetect/hwdetect.sh
@@ -34,7 +34,7 @@ check_i2c_devices() {
 		i2c_bus=$(i2cdetect -y ${i} | awk '{if (NR!=1) {print}}' | awk '{$1=""}1')
 		if [ -n "$(echo $i2c_bus | grep '[0-9]')" ];
 		then
-			echo "An i2c device is connected"
+			echo "An i2c device is connected to a bus: ${i}"
 		fi
 	done
 }


### PR DESCRIPTION
A bash script that detects whether sd cards, flash drives, i2c devices and usb-ttl convertors are connected. 
Each hardware type is served by a separate function with a descriptive name.
All the caveats are described in commit messages.