### PR TITLE
A solution for device tree (dt)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[*.dts]
+indent_style = tab
+indent_size = 8

--- a/dt/armbianEnv.txt
+++ b/dt/armbianEnv.txt
@@ -1,0 +1,9 @@
+verbosity=1
+logo=disabled
+console=both
+disp_mode=1920x1080p60
+overlay_prefix=sun8i-h3
+rootdev=UUID=24819d8b-5022-4647-a64d-eb65eea3ea11
+rootfstype=ext4
+overlays=i2c0 bme280
+usbstoragequirks=0x2537:0x1066:u,0x2537:0x1068:u

--- a/dt/sun8i-h3-bme280-overlay.dts
+++ b/dt/sun8i-h3-bme280-overlay.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+
+	fragment@0 {
+		target-path = "/aliases";
+		__overlay__ {
+			bme280 = "/soc/i2c@1c2ac00/bme280@76";
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c0>;
+		__overlay__ {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			bme280@76 {
+				compatible = "bme280";
+				reg = <0x76>;
+				status = "okay";
+			};
+		};
+	};
+};

--- a/dt/sun8i-h3-i2c0-overlay.dts
+++ b/dt/sun8i-h3-i2c0-overlay.dts
@@ -1,0 +1,25 @@
+/dts-v1/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+
+	fragment@0 {
+		target-path = "/aliases";
+
+		__overlay__ {
+			i2c0 = "/soc/i2c@1c2ac00";
+		};
+	};
+
+	fragment@1 {
+		target = <0xffffffff>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	__fixups__ {
+		i2c0 = "/fragment@1:target:0";
+	};
+};

--- a/dt/sun8i-h3-orangepi-one.dts
+++ b/dt/sun8i-h3-orangepi-one.dts
@@ -1,0 +1,1386 @@
+/dts-v1/;
+
+/ {
+	interrupt-parent = <0x01>;
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+	model = "Xunlong Orange Pi One";
+	compatible = "xunlong,orangepi-one\0allwinner,sun8i-h3";
+
+	chosen {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+		stdout-path = "serial0:115200n8";
+
+		framebuffer-hdmi {
+			compatible = "allwinner,simple-framebuffer\0simple-framebuffer";
+			allwinner,pipeline = "mixer0-lcd0-hdmi";
+			clocks = <0x02 0x06 0x03 0x66 0x03 0x6f>;
+			status = "disabled";
+		};
+
+		framebuffer-tve {
+			compatible = "allwinner,simple-framebuffer\0simple-framebuffer";
+			allwinner,pipeline = "mixer1-lcd1-tve";
+			clocks = <0x02 0x07 0x03 0x67>;
+			status = "disabled";
+		};
+	};
+
+	clocks {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		osc24M_clk {
+			#clock-cells = <0x00>;
+			compatible = "fixed-clock";
+			clock-frequency = <0x16e3600>;
+			clock-accuracy = <0xc350>;
+			clock-output-names = "osc24M";
+			phandle = <0x0e>;
+		};
+
+		osc32k_clk {
+			#clock-cells = <0x00>;
+			compatible = "fixed-clock";
+			clock-frequency = <0x8000>;
+			clock-accuracy = <0xc350>;
+			clock-output-names = "ext_osc32k";
+			phandle = <0x24>;
+		};
+	};
+
+	opp_table0 {
+		compatible = "operating-points-v2";
+		opp-shared;
+		phandle = <0x29>;
+
+		opp-480000000 {
+			opp-hz = <0x00 0x1c9c3800>;
+			opp-microvolt = <0xfde80 0xfde80 0x13d620>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-648000000 {
+			opp-hz = <0x00 0x269fb200>;
+			opp-microvolt = <0xfde80 0xfde80 0x13d620>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-816000000 {
+			opp-hz = <0x00 0x30a32c00>;
+			opp-microvolt = <0x10c8e0 0x10c8e0 0x13d620>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-960000000 {
+			opp-hz = <0x00 0x39387000>;
+			opp-microvolt = <0x124f80 0x124f80 0x13d620>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-1008000000 {
+			opp-hz = <0x00 0x3c14dc00>;
+			opp-microvolt = <0x124f80 0x124f80 0x13d620>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-1104000000 {
+			opp-hz = <0x00 0x41cdb400>;
+			opp-microvolt = <0x142440 0x142440 0x142440>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-1200000000 {
+			opp-hz = <0x00 0x47868c00>;
+			opp-microvolt = <0x142440 0x142440 0x142440>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-1296000000 {
+			opp-hz = <0x00 0x4d3f6400>;
+			opp-microvolt = <0x147260 0x147260 0x147260>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+
+		opp-1368000000 {
+			opp-hz = <0x00 0x518a0600>;
+			opp-microvolt = <0x155cc0 0x155cc0 0x155cc0>;
+			clock-latency-ns = <0x3b9b0>;
+		};
+	};
+
+	display-engine {
+		compatible = "allwinner,sun8i-h3-display-engine";
+		allwinner,pipelines = <0x04>;
+		status = "okay";
+		phandle = <0x33>;
+	};
+
+	soc {
+		compatible = "simple-bus";
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		clock@1000000 {
+			reg = <0x1000000 0x100000>;
+			clocks = <0x03 0x65 0x03 0x30>;
+			clock-names = "mod\0bus";
+			resets = <0x03 0x22>;
+			#clock-cells = <0x01>;
+			#reset-cells = <0x01>;
+			compatible = "allwinner,sun8i-h3-de2-clk";
+			phandle = <0x02>;
+		};
+
+		mixer@1100000 {
+			compatible = "allwinner,sun8i-h3-de2-mixer-0";
+			reg = <0x1100000 0x100000>;
+			clocks = <0x02 0x00 0x02 0x06>;
+			clock-names = "bus\0mod";
+			resets = <0x02 0x00>;
+			phandle = <0x04>;
+
+			ports {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+
+				port@1 {
+					reg = <0x01>;
+					phandle = <0x34>;
+
+					endpoint {
+						remote-endpoint = <0x05>;
+						phandle = <0x06>;
+					};
+				};
+			};
+		};
+
+		dma-controller@1c02000 {
+			compatible = "allwinner,sun8i-h3-dma";
+			reg = <0x1c02000 0x1000>;
+			interrupts = <0x00 0x32 0x04>;
+			clocks = <0x03 0x15>;
+			resets = <0x03 0x06>;
+			#dma-cells = <0x01>;
+			phandle = <0x13>;
+		};
+
+		lcd-controller@1c0c000 {
+			compatible = "allwinner,sun8i-h3-tcon-tv\0allwinner,sun8i-a83t-tcon-tv";
+			reg = <0x1c0c000 0x1000>;
+			interrupts = <0x00 0x56 0x04>;
+			clocks = <0x03 0x2a 0x03 0x66>;
+			clock-names = "ahb\0tcon-ch1";
+			resets = <0x03 0x1b>;
+			reset-names = "lcd";
+			phandle = <0x35>;
+
+			ports {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+
+				port@0 {
+					reg = <0x00>;
+					phandle = <0x36>;
+
+					endpoint {
+						remote-endpoint = <0x06>;
+						phandle = <0x05>;
+					};
+				};
+
+				port@1 {
+					#address-cells = <0x01>;
+					#size-cells = <0x00>;
+					reg = <0x01>;
+					phandle = <0x37>;
+
+					endpoint@1 {
+						reg = <0x01>;
+						remote-endpoint = <0x07>;
+						phandle = <0x22>;
+					};
+				};
+			};
+		};
+
+		mmc@1c0f000 {
+			reg = <0x1c0f000 0x1000>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x08>;
+			resets = <0x03 0x07>;
+			reset-names = "ahb";
+			interrupts = <0x00 0x3c 0x04>;
+			bus-width = <0x04>;
+			status = "okay";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			compatible = "allwinner,sun7i-a20-mmc";
+			clocks = <0x03 0x16 0x03 0x47 0x03 0x49 0x03 0x48>;
+			clock-names = "ahb\0mmc\0output\0sample";
+			vmmc-supply = <0x09>;
+			cd-gpios = <0x0a 0x05 0x06 0x01>;
+			phandle = <0x38>;
+		};
+
+		mmc@1c10000 {
+			reg = <0x1c10000 0x1000>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x0b>;
+			resets = <0x03 0x08>;
+			reset-names = "ahb";
+			interrupts = <0x00 0x3d 0x04>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			compatible = "allwinner,sun7i-a20-mmc";
+			clocks = <0x03 0x17 0x03 0x4a 0x03 0x4c 0x03 0x4b>;
+			clock-names = "ahb\0mmc\0output\0sample";
+			phandle = <0x39>;
+		};
+
+		mmc@1c11000 {
+			reg = <0x1c11000 0x1000>;
+			resets = <0x03 0x09>;
+			reset-names = "ahb";
+			interrupts = <0x00 0x3e 0x04>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			compatible = "allwinner,sun7i-a20-mmc";
+			clocks = <0x03 0x18 0x03 0x4d 0x03 0x4f 0x03 0x4e>;
+			clock-names = "ahb\0mmc\0output\0sample";
+			phandle = <0x3a>;
+		};
+
+		eeprom@1c14000 {
+			reg = <0x1c14000 0x400>;
+			compatible = "allwinner,sun8i-h3-sid";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			phandle = <0x3b>;
+
+			thermal-sensor-calibration@34 {
+				reg = <0x34 0x04>;
+				phandle = <0x28>;
+			};
+		};
+
+		usb@1c19000 {
+			compatible = "allwinner,sun8i-h3-musb";
+			reg = <0x1c19000 0x400>;
+			clocks = <0x03 0x20>;
+			resets = <0x03 0x11>;
+			interrupts = <0x00 0x47 0x04>;
+			interrupt-names = "mc";
+			phys = <0x0c 0x00>;
+			phy-names = "usb";
+			extcon = <0x0c 0x00>;
+			dr_mode = "otg";
+			status = "okay";
+			phandle = <0x3c>;
+		};
+
+		phy@1c19400 {
+			compatible = "allwinner,sun8i-h3-usb-phy";
+			reg = <0x1c19400 0x2c 0x1c1a800 0x04 0x1c1b800 0x04 0x1c1c800 0x04 0x1c1d800 0x04>;
+			reg-names = "phy_ctrl\0pmu0\0pmu1\0pmu2\0pmu3";
+			clocks = <0x03 0x58 0x03 0x59 0x03 0x5a 0x03 0x5b>;
+			clock-names = "usb0_phy\0usb1_phy\0usb2_phy\0usb3_phy";
+			resets = <0x03 0x00 0x03 0x01 0x03 0x02 0x03 0x03>;
+			reset-names = "usb0_reset\0usb1_reset\0usb2_reset\0usb3_reset";
+			status = "okay";
+			#phy-cells = <0x01>;
+			usb0_id_det-gpios = <0x0a 0x06 0x0c 0x00>;
+			usb0_vbus-supply = <0x0d>;
+			phandle = <0x0c>;
+		};
+
+		usb@1c1a000 {
+			compatible = "allwinner,sun8i-h3-ehci\0generic-ehci";
+			reg = <0x1c1a000 0x100>;
+			interrupts = <0x00 0x48 0x04>;
+			clocks = <0x03 0x21 0x03 0x25>;
+			resets = <0x03 0x12 0x03 0x16>;
+			status = "okay";
+			phandle = <0x3d>;
+		};
+
+		usb@1c1a400 {
+			compatible = "allwinner,sun8i-h3-ohci\0generic-ohci";
+			reg = <0x1c1a400 0x100>;
+			interrupts = <0x00 0x49 0x04>;
+			clocks = <0x03 0x21 0x03 0x25 0x03 0x5c>;
+			resets = <0x03 0x12 0x03 0x16>;
+			status = "okay";
+			phandle = <0x3e>;
+		};
+
+		usb@1c1b000 {
+			compatible = "allwinner,sun8i-h3-ehci\0generic-ehci";
+			reg = <0x1c1b000 0x100>;
+			interrupts = <0x00 0x4a 0x04>;
+			clocks = <0x03 0x22 0x03 0x26>;
+			resets = <0x03 0x13 0x03 0x17>;
+			phys = <0x0c 0x01>;
+			status = "okay";
+			phandle = <0x3f>;
+		};
+
+		usb@1c1b400 {
+			compatible = "allwinner,sun8i-h3-ohci\0generic-ohci";
+			reg = <0x1c1b400 0x100>;
+			interrupts = <0x00 0x4b 0x04>;
+			clocks = <0x03 0x22 0x03 0x26 0x03 0x5d>;
+			resets = <0x03 0x13 0x03 0x17>;
+			phys = <0x0c 0x01>;
+			status = "okay";
+			phandle = <0x40>;
+		};
+
+		usb@1c1c000 {
+			compatible = "allwinner,sun8i-h3-ehci\0generic-ehci";
+			reg = <0x1c1c000 0x100>;
+			interrupts = <0x00 0x4c 0x04>;
+			clocks = <0x03 0x23 0x03 0x27>;
+			resets = <0x03 0x14 0x03 0x18>;
+			phys = <0x0c 0x02>;
+			status = "disabled";
+			phandle = <0x41>;
+		};
+
+		usb@1c1c400 {
+			compatible = "allwinner,sun8i-h3-ohci\0generic-ohci";
+			reg = <0x1c1c400 0x100>;
+			interrupts = <0x00 0x4d 0x04>;
+			clocks = <0x03 0x23 0x03 0x27 0x03 0x5e>;
+			resets = <0x03 0x14 0x03 0x18>;
+			phys = <0x0c 0x02>;
+			status = "disabled";
+			phandle = <0x42>;
+		};
+
+		usb@1c1d000 {
+			compatible = "allwinner,sun8i-h3-ehci\0generic-ehci";
+			reg = <0x1c1d000 0x100>;
+			interrupts = <0x00 0x4e 0x04>;
+			clocks = <0x03 0x24 0x03 0x28>;
+			resets = <0x03 0x15 0x03 0x19>;
+			phys = <0x0c 0x03>;
+			status = "disabled";
+			phandle = <0x43>;
+		};
+
+		usb@1c1d400 {
+			compatible = "allwinner,sun8i-h3-ohci\0generic-ohci";
+			reg = <0x1c1d400 0x100>;
+			interrupts = <0x00 0x4f 0x04>;
+			clocks = <0x03 0x24 0x03 0x28 0x03 0x5f>;
+			resets = <0x03 0x15 0x03 0x19>;
+			phys = <0x0c 0x03>;
+			status = "disabled";
+			phandle = <0x44>;
+		};
+
+		clock@1c20000 {
+			reg = <0x1c20000 0x400>;
+			clocks = <0x0e 0x0f 0x00>;
+			clock-names = "hosc\0losc";
+			#clock-cells = <0x01>;
+			#reset-cells = <0x01>;
+			compatible = "allwinner,sun8i-h3-ccu";
+			phandle = <0x03>;
+		};
+
+		pinctrl@1c20800 {
+			reg = <0x1c20800 0x400>;
+			interrupts = <0x00 0x0b 0x04 0x00 0x11 0x04>;
+			clocks = <0x03 0x36 0x0e 0x0f 0x00>;
+			clock-names = "apb\0hosc\0losc";
+			gpio-controller;
+			#gpio-cells = <0x03>;
+			interrupt-controller;
+			#interrupt-cells = <0x03>;
+			compatible = "allwinner,sun8i-h3-pinctrl";
+			phandle = <0x0a>;
+
+			csi-pins {
+				pins = "PE0\0PE2\0PE3\0PE4\0PE5\0PE6\0PE7\0PE8\0PE9\0PE10\0PE11";
+				function = "csi";
+				phandle = <0x20>;
+			};
+
+			emac-rgmii-pins {
+				pins = "PD0\0PD1\0PD2\0PD3\0PD4\0PD5\0PD7\0PD8\0PD9\0PD10\0PD12\0PD13\0PD15\0PD16\0PD17";
+				function = "emac";
+				drive-strength = <0x28>;
+				phandle = <0x45>;
+			};
+
+			i2c0-pins {
+				pins = "PA11\0PA12";
+				function = "i2c0";
+				phandle = <0x1d>;
+			};
+
+			i2c1-pins {
+				pins = "PA18\0PA19";
+				function = "i2c1";
+				phandle = <0x1e>;
+			};
+
+			i2c2-pins {
+				pins = "PE12\0PE13";
+				function = "i2c2";
+				phandle = <0x1f>;
+			};
+
+			i2s0-pins {
+				pins = "PA18\0PA19\0PA20\0PA21";
+				function = "i2s0";
+				phandle = <0x46>;
+			};
+
+			i2s1-pins {
+				pins = "PG10\0PG11\0PG12\0PG13";
+				function = "i2s1";
+				phandle = <0x47>;
+			};
+
+			mmc0-pins {
+				pins = "PF0\0PF1\0PF2\0PF3\0PF4\0PF5";
+				function = "mmc0";
+				drive-strength = <0x1e>;
+				bias-pull-up;
+				phandle = <0x08>;
+			};
+
+			mmc1-pins {
+				pins = "PG0\0PG1\0PG2\0PG3\0PG4\0PG5";
+				function = "mmc1";
+				drive-strength = <0x1e>;
+				bias-pull-up;
+				phandle = <0x0b>;
+			};
+
+			mmc2-8bit-pins {
+				pins = "PC5\0PC6\0PC8\0PC9\0PC10\0PC11\0PC12\0PC13\0PC14\0PC15\0PC16";
+				function = "mmc2";
+				drive-strength = <0x1e>;
+				bias-pull-up;
+				phandle = <0x48>;
+			};
+
+			spdif-tx-pin {
+				pins = "PA17";
+				function = "spdif";
+				phandle = <0x49>;
+			};
+
+			spi0-pins {
+				pins = "PC0\0PC1\0PC2\0PC3";
+				function = "spi0";
+				phandle = <0x14>;
+			};
+
+			spi1-pins {
+				pins = "PA15\0PA16\0PA14\0PA13";
+				function = "spi1";
+				phandle = <0x15>;
+			};
+
+			uart0-pa-pins {
+				pins = "PA4\0PA5";
+				function = "uart0";
+				phandle = <0x19>;
+			};
+
+			uart1-pins {
+				pins = "PG6\0PG7";
+				function = "uart1";
+				phandle = <0x1a>;
+			};
+
+			uart1-rts-cts-pins {
+				pins = "PG8\0PG9";
+				function = "uart1";
+				phandle = <0x4a>;
+			};
+
+			uart2-pins {
+				pins = "PA0\0PA1";
+				function = "uart2";
+				phandle = <0x1b>;
+			};
+
+			uart2-rts-cts-pins {
+				pins = "PA2\0PA3";
+				function = "uart2";
+				phandle = <0x4b>;
+			};
+
+			uart3-pins {
+				pins = "PA13\0PA14";
+				function = "uart3";
+				phandle = <0x1c>;
+			};
+
+			uart3-rts-cts-pins {
+				pins = "PA15\0PA16";
+				function = "uart3";
+				phandle = <0x4c>;
+			};
+		};
+
+		timer@1c20c00 {
+			compatible = "allwinner,sun4i-a10-timer";
+			reg = <0x1c20c00 0xa0>;
+			interrupts = <0x00 0x12 0x04 0x00 0x13 0x04>;
+			clocks = <0x0e>;
+		};
+
+		ethernet@1c30000 {
+			compatible = "allwinner,sun8i-h3-emac";
+			syscon = <0x10>;
+			reg = <0x1c30000 0x10000>;
+			interrupts = <0x00 0x52 0x04>;
+			interrupt-names = "macirq";
+			resets = <0x03 0x0c>;
+			reset-names = "stmmaceth";
+			clocks = <0x03 0x1b>;
+			clock-names = "stmmaceth";
+			status = "okay";
+			phy-handle = <0x11>;
+			phy-mode = "mii";
+			allwinner,leds-active-low;
+			phandle = <0x4d>;
+
+			mdio {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "snps,dwmac-mdio";
+				phandle = <0x12>;
+			};
+
+			mdio-mux {
+				compatible = "allwinner,sun8i-h3-mdio-mux";
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				mdio-parent-bus = <0x12>;
+
+				mdio@1 {
+					compatible = "allwinner,sun8i-h3-mdio-internal";
+					reg = <0x01>;
+					#address-cells = <0x01>;
+					#size-cells = <0x00>;
+					phandle = <0x4e>;
+
+					ethernet-phy@1 {
+						compatible = "ethernet-phy-ieee802.3-c22";
+						reg = <0x01>;
+						clocks = <0x03 0x43>;
+						resets = <0x03 0x27>;
+						phandle = <0x11>;
+					};
+				};
+
+				mdio@2 {
+					reg = <0x02>;
+					#address-cells = <0x01>;
+					#size-cells = <0x00>;
+					phandle = <0x4f>;
+				};
+			};
+		};
+
+		spi@1c68000 {
+			compatible = "allwinner,sun8i-h3-spi";
+			reg = <0x1c68000 0x1000>;
+			interrupts = <0x00 0x41 0x04>;
+			clocks = <0x03 0x1e 0x03 0x52>;
+			clock-names = "ahb\0mod";
+			dmas = <0x13 0x17 0x13 0x17>;
+			dma-names = "rx\0tx";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x14>;
+			resets = <0x03 0x0f>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			phandle = <0x50>;
+		};
+
+		spi@1c69000 {
+			compatible = "allwinner,sun8i-h3-spi";
+			reg = <0x1c69000 0x1000>;
+			interrupts = <0x00 0x42 0x04>;
+			clocks = <0x03 0x1f 0x03 0x53>;
+			clock-names = "ahb\0mod";
+			dmas = <0x13 0x18 0x13 0x18>;
+			dma-names = "rx\0tx";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x15>;
+			resets = <0x03 0x10>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			phandle = <0x51>;
+		};
+
+		watchdog@1c20ca0 {
+			compatible = "allwinner,sun6i-a31-wdt";
+			reg = <0x1c20ca0 0x20>;
+			interrupts = <0x00 0x19 0x04>;
+			phandle = <0x52>;
+		};
+
+		spdif@1c21000 {
+			#sound-dai-cells = <0x00>;
+			compatible = "allwinner,sun8i-h3-spdif";
+			reg = <0x1c21000 0x400>;
+			interrupts = <0x00 0x0c 0x04>;
+			clocks = <0x03 0x35 0x03 0x57>;
+			resets = <0x03 0x29>;
+			clock-names = "apb\0spdif";
+			dmas = <0x13 0x02>;
+			dma-names = "tx";
+			status = "disabled";
+			phandle = <0x53>;
+		};
+
+		pwm@1c21400 {
+			compatible = "allwinner,sun8i-h3-pwm";
+			reg = <0x1c21400 0x08>;
+			clocks = <0x0e>;
+			#pwm-cells = <0x03>;
+			status = "disabled";
+			phandle = <0x54>;
+		};
+
+		i2s@1c22000 {
+			#sound-dai-cells = <0x00>;
+			compatible = "allwinner,sun8i-h3-i2s";
+			reg = <0x1c22000 0x400>;
+			interrupts = <0x00 0x0d 0x04>;
+			clocks = <0x03 0x38 0x03 0x54>;
+			clock-names = "apb\0mod";
+			dmas = <0x13 0x03 0x13 0x03>;
+			resets = <0x03 0x2b>;
+			dma-names = "rx\0tx";
+			status = "disabled";
+			phandle = <0x55>;
+		};
+
+		i2s@1c22400 {
+			#sound-dai-cells = <0x00>;
+			compatible = "allwinner,sun8i-h3-i2s";
+			reg = <0x1c22400 0x400>;
+			interrupts = <0x00 0x0e 0x04>;
+			clocks = <0x03 0x39 0x03 0x55>;
+			clock-names = "apb\0mod";
+			dmas = <0x13 0x04 0x13 0x04>;
+			resets = <0x03 0x2c>;
+			dma-names = "rx\0tx";
+			status = "disabled";
+			phandle = <0x56>;
+		};
+
+		i2s@1c22800 {
+			#sound-dai-cells = <0x00>;
+			compatible = "allwinner,sun8i-h3-i2s";
+			reg = <0x1c22800 0x400>;
+			interrupts = <0x00 0x0f 0x04>;
+			clocks = <0x03 0x3a 0x03 0x56>;
+			clock-names = "apb\0mod";
+			dmas = <0x13 0x1b>;
+			resets = <0x03 0x2d>;
+			dma-names = "tx";
+			phandle = <0x17>;
+		};
+
+		sound {
+			compatible = "simple-audio-card";
+			simple-audio-card,format = "i2s";
+			simple-audio-card,name = "allwinner,hdmi";
+			simple-audio-card,mclk-fs = <0x100>;
+			phandle = <0x57>;
+
+			simple-audio-card,codec {
+				sound-dai = <0x16>;
+			};
+
+			simple-audio-card,cpu {
+				sound-dai = <0x17>;
+			};
+		};
+
+		codec@1c22c00 {
+			#sound-dai-cells = <0x00>;
+			compatible = "allwinner,sun8i-h3-codec";
+			reg = <0x1c22c00 0x400>;
+			interrupts = <0x00 0x1d 0x04>;
+			clocks = <0x03 0x34 0x03 0x6d>;
+			clock-names = "apb\0codec";
+			resets = <0x03 0x28>;
+			dmas = <0x13 0x0f 0x13 0x0f>;
+			dma-names = "rx\0tx";
+			allwinner,codec-analog-controls = <0x18>;
+			status = "disabled";
+			phandle = <0x58>;
+		};
+
+		serial@1c28000 {
+			compatible = "snps,dw-apb-uart";
+			reg = <0x1c28000 0x400>;
+			interrupts = <0x00 0x00 0x04>;
+			reg-shift = <0x02>;
+			reg-io-width = <0x04>;
+			clocks = <0x03 0x3e>;
+			resets = <0x03 0x31>;
+			dmas = <0x13 0x06 0x13 0x06>;
+			dma-names = "rx\0tx";
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x19>;
+			phandle = <0x59>;
+		};
+
+		serial@1c28400 {
+			compatible = "snps,dw-apb-uart";
+			reg = <0x1c28400 0x400>;
+			interrupts = <0x00 0x01 0x04>;
+			reg-shift = <0x02>;
+			reg-io-width = <0x04>;
+			clocks = <0x03 0x3f>;
+			resets = <0x03 0x32>;
+			dmas = <0x13 0x07 0x13 0x07>;
+			dma-names = "rx\0tx";
+			status = "disabled";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1a>;
+			phandle = <0x5a>;
+		};
+
+		serial@1c28800 {
+			compatible = "snps,dw-apb-uart";
+			reg = <0x1c28800 0x400>;
+			interrupts = <0x00 0x02 0x04>;
+			reg-shift = <0x02>;
+			reg-io-width = <0x04>;
+			clocks = <0x03 0x40>;
+			resets = <0x03 0x33>;
+			dmas = <0x13 0x08 0x13 0x08>;
+			dma-names = "rx\0tx";
+			status = "disabled";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1b>;
+			phandle = <0x5b>;
+		};
+
+		serial@1c28c00 {
+			compatible = "snps,dw-apb-uart";
+			reg = <0x1c28c00 0x400>;
+			interrupts = <0x00 0x03 0x04>;
+			reg-shift = <0x02>;
+			reg-io-width = <0x04>;
+			clocks = <0x03 0x41>;
+			resets = <0x03 0x34>;
+			dmas = <0x13 0x09 0x13 0x09>;
+			dma-names = "rx\0tx";
+			status = "disabled";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1c>;
+			phandle = <0x5c>;
+		};
+
+		i2c@1c2ac00 {
+			compatible = "allwinner,sun6i-a31-i2c";
+			reg = <0x1c2ac00 0x400>;
+			interrupts = <0x00 0x06 0x04>;
+			clocks = <0x03 0x3b>;
+			resets = <0x03 0x2e>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1d>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			phandle = <0x5d>;
+		};
+
+		i2c@1c2b000 {
+			compatible = "allwinner,sun6i-a31-i2c";
+			reg = <0x1c2b000 0x400>;
+			interrupts = <0x00 0x07 0x04>;
+			clocks = <0x03 0x3c>;
+			resets = <0x03 0x2f>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1e>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			phandle = <0x5e>;
+		};
+
+		i2c@1c2b400 {
+			compatible = "allwinner,sun6i-a31-i2c";
+			reg = <0x1c2b400 0x400>;
+			interrupts = <0x00 0x08 0x04>;
+			clocks = <0x03 0x3d>;
+			resets = <0x03 0x30>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1f>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			phandle = <0x5f>;
+		};
+
+		interrupt-controller@1c81000 {
+			compatible = "arm,gic-400";
+			reg = <0x1c81000 0x1000 0x1c82000 0x2000 0x1c84000 0x2000 0x1c86000 0x2000>;
+			interrupt-controller;
+			#interrupt-cells = <0x03>;
+			interrupts = <0x01 0x09 0xf04>;
+			phandle = <0x01>;
+		};
+
+		camera@1cb0000 {
+			compatible = "allwinner,sun8i-h3-csi";
+			reg = <0x1cb0000 0x1000>;
+			interrupts = <0x00 0x54 0x04>;
+			clocks = <0x03 0x2d 0x03 0x6a 0x03 0x62>;
+			clock-names = "bus\0mod\0ram";
+			resets = <0x03 0x1e>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x20>;
+			status = "disabled";
+			phandle = <0x60>;
+		};
+
+		hdmi@1ee0000 {
+			#sound-dai-cells = <0x00>;
+			compatible = "allwinner,sun8i-h3-dw-hdmi\0allwinner,sun8i-a83t-dw-hdmi";
+			reg = <0x1ee0000 0x10000>;
+			reg-io-width = <0x01>;
+			interrupts = <0x00 0x58 0x04>;
+			clocks = <0x03 0x2f 0x03 0x70 0x03 0x6f>;
+			clock-names = "iahb\0isfr\0tmds";
+			resets = <0x03 0x21>;
+			reset-names = "ctrl";
+			phys = <0x21>;
+			phy-names = "hdmi-phy";
+			status = "okay";
+			phandle = <0x16>;
+
+			ports {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+
+				port@0 {
+					reg = <0x00>;
+					phandle = <0x61>;
+
+					endpoint {
+						remote-endpoint = <0x22>;
+						phandle = <0x07>;
+					};
+				};
+
+				port@1 {
+					reg = <0x01>;
+					phandle = <0x62>;
+
+					endpoint {
+						remote-endpoint = <0x23>;
+						phandle = <0x32>;
+					};
+				};
+			};
+		};
+
+		hdmi-phy@1ef0000 {
+			compatible = "allwinner,sun8i-h3-hdmi-phy";
+			reg = <0x1ef0000 0x10000>;
+			clocks = <0x03 0x2f 0x03 0x70 0x03 0x06>;
+			clock-names = "bus\0mod\0pll-0";
+			resets = <0x03 0x20>;
+			reset-names = "phy";
+			#phy-cells = <0x00>;
+			phandle = <0x21>;
+		};
+
+		rtc@1f00000 {
+			reg = <0x1f00000 0x400>;
+			interrupts = <0x00 0x28 0x04 0x00 0x29 0x04>;
+			clock-output-names = "osc32k\0osc32k-out\0iosc";
+			clocks = <0x24>;
+			#clock-cells = <0x01>;
+			compatible = "allwinner,sun8i-h3-rtc";
+			phandle = <0x0f>;
+		};
+
+		clock@1f01400 {
+			compatible = "allwinner,sun8i-h3-r-ccu";
+			reg = <0x1f01400 0x100>;
+			clocks = <0x0e 0x0f 0x00 0x0f 0x02 0x03 0x09>;
+			clock-names = "hosc\0losc\0iosc\0pll-periph";
+			#clock-cells = <0x01>;
+			#reset-cells = <0x01>;
+			phandle = <0x25>;
+		};
+
+		codec-analog@1f015c0 {
+			compatible = "allwinner,sun8i-h3-codec-analog";
+			reg = <0x1f015c0 0x04>;
+			phandle = <0x18>;
+		};
+
+		ir@1f02000 {
+			compatible = "allwinner,sun5i-a13-ir";
+			clocks = <0x25 0x04 0x25 0x0b>;
+			clock-names = "apb\0ir";
+			resets = <0x25 0x00>;
+			interrupts = <0x00 0x25 0x04>;
+			reg = <0x1f02000 0x400>;
+			status = "disabled";
+			phandle = <0x63>;
+		};
+
+		i2c@1f02400 {
+			compatible = "allwinner,sun6i-a31-i2c";
+			reg = <0x1f02400 0x400>;
+			interrupts = <0x00 0x2c 0x04>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x26>;
+			clocks = <0x25 0x09>;
+			resets = <0x25 0x05>;
+			status = "disabled";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			phandle = <0x64>;
+		};
+
+		pinctrl@1f02c00 {
+			compatible = "allwinner,sun8i-h3-r-pinctrl";
+			reg = <0x1f02c00 0x400>;
+			interrupts = <0x00 0x2d 0x04>;
+			clocks = <0x25 0x03 0x0e 0x0f 0x00>;
+			clock-names = "apb\0hosc\0losc";
+			gpio-controller;
+			#gpio-cells = <0x03>;
+			interrupt-controller;
+			#interrupt-cells = <0x03>;
+			phandle = <0x31>;
+
+			r-ir-rx-pin {
+				pins = "PL11";
+				function = "s_cir_rx";
+				phandle = <0x65>;
+			};
+
+			r-i2c-pins {
+				pins = "PL0\0PL1";
+				function = "s_i2c";
+				phandle = <0x26>;
+			};
+		};
+
+		system-control@1c00000 {
+			compatible = "allwinner,sun8i-h3-system-control";
+			reg = <0x1c00000 0x1000>;
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			ranges;
+			phandle = <0x10>;
+
+			sram@1d00000 {
+				compatible = "mmio-sram";
+				reg = <0x1d00000 0x80000>;
+				#address-cells = <0x01>;
+				#size-cells = <0x01>;
+				ranges = <0x00 0x1d00000 0x80000>;
+				phandle = <0x66>;
+
+				sram-section@0 {
+					compatible = "allwinner,sun8i-h3-sram-c1\0allwinner,sun4i-a10-sram-c1";
+					reg = <0x00 0x80000>;
+					phandle = <0x27>;
+				};
+			};
+		};
+
+		video-codec@1c0e000 {
+			compatible = "allwinner,sun8i-h3-video-engine";
+			reg = <0x1c0e000 0x1000>;
+			clocks = <0x03 0x29 0x03 0x6c 0x03 0x61>;
+			clock-names = "ahb\0mod\0ram";
+			resets = <0x03 0x1a>;
+			interrupts = <0x00 0x3a 0x04>;
+			allwinner,sram = <0x27 0x01>;
+		};
+
+		gpu@1c40000 {
+			compatible = "allwinner,sun8i-h3-mali\0arm,mali-400";
+			reg = <0x1c40000 0x10000>;
+			interrupts = <0x00 0x61 0x04 0x00 0x62 0x04 0x00 0x63 0x04 0x00 0x64 0x04 0x00 0x66 0x04 0x00 0x67 0x04 0x00 0x65 0x04>;
+			interrupt-names = "gp\0gpmmu\0pp0\0ppmmu0\0pp1\0ppmmu1\0pmu";
+			clocks = <0x03 0x31 0x03 0x72>;
+			clock-names = "bus\0core";
+			resets = <0x03 0x23>;
+			assigned-clocks = <0x03 0x72>;
+			assigned-clock-rates = <0x16e36000>;
+			phandle = <0x67>;
+		};
+
+		ths@1c25000 {
+			compatible = "allwinner,sun8i-h3-ths";
+			reg = <0x1c25000 0x400>;
+			interrupts = <0x00 0x1f 0x04>;
+			resets = <0x03 0x2a>;
+			clocks = <0x03 0x37 0x03 0x45>;
+			clock-names = "bus\0mod";
+			nvmem-cells = <0x28>;
+			nvmem-cell-names = "calibration";
+			#thermal-sensor-cells = <0x00>;
+			phandle = <0x2b>;
+		};
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		cpu@0 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			reg = <0x00>;
+			clocks = <0x03 0x0e>;
+			clock-names = "cpu";
+			operating-points-v2 = <0x29>;
+			#cooling-cells = <0x02>;
+			cpu-supply = <0x2a>;
+			phandle = <0x2d>;
+		};
+
+		cpu@1 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			reg = <0x01>;
+			clocks = <0x03 0x0e>;
+			clock-names = "cpu";
+			operating-points-v2 = <0x29>;
+			#cooling-cells = <0x02>;
+			phandle = <0x2e>;
+		};
+
+		cpu@2 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			reg = <0x02>;
+			clocks = <0x03 0x0e>;
+			clock-names = "cpu";
+			operating-points-v2 = <0x29>;
+			#cooling-cells = <0x02>;
+			phandle = <0x2f>;
+		};
+
+		cpu@3 {
+			compatible = "arm,cortex-a7";
+			device_type = "cpu";
+			reg = <0x03>;
+			clocks = <0x03 0x0e>;
+			clock-names = "cpu";
+			operating-points-v2 = <0x29>;
+			#cooling-cells = <0x02>;
+			phandle = <0x30>;
+		};
+	};
+
+	thermal-zones {
+
+		cpu-thermal {
+			polling-delay-passive = <0x00>;
+			polling-delay = <0x00>;
+			thermal-sensors = <0x2b 0x00>;
+			phandle = <0x68>;
+
+			trips {
+
+				cpu-hot {
+					temperature = <0x13880>;
+					hysteresis = <0x7d0>;
+					type = "passive";
+					phandle = <0x2c>;
+				};
+
+				cpu-very-hot {
+					temperature = <0x186a0>;
+					hysteresis = <0x00>;
+					type = "critical";
+					phandle = <0x69>;
+				};
+			};
+
+			cooling-maps {
+
+				cpu-hot-limit {
+					trip = <0x2c>;
+					cooling-device = <0x2d 0xffffffff 0xffffffff 0x2e 0xffffffff 0xffffffff 0x2f 0xffffffff 0xffffffff 0x30 0xffffffff 0xffffffff>;
+				};
+			};
+		};
+	};
+
+	timer {
+		compatible = "arm,armv7-timer";
+		interrupts = <0x01 0x0d 0xf08 0x01 0x0e 0xf08 0x01 0x0b 0xf08 0x01 0x0a 0xf08>;
+	};
+
+	ahci-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "ahci-5v";
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		regulator-boot-on;
+		enable-active-high;
+		gpio = <0x0a 0x01 0x08 0x00>;
+		status = "disabled";
+		phandle = <0x6a>;
+	};
+
+	usb0-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb0-vbus";
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		enable-active-high;
+		gpio = <0x31 0x00 0x02 0x00>;
+		status = "okay";
+		phandle = <0x0d>;
+	};
+
+	usb1-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb1-vbus";
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		regulator-boot-on;
+		enable-active-high;
+		gpio = <0x0a 0x07 0x06 0x00>;
+		status = "disabled";
+		phandle = <0x6b>;
+	};
+
+	usb2-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb2-vbus";
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		regulator-boot-on;
+		enable-active-high;
+		gpio = <0x0a 0x07 0x03 0x00>;
+		status = "disabled";
+		phandle = <0x6c>;
+	};
+
+	vcc3v0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v0";
+		regulator-min-microvolt = <0x2dc6c0>;
+		regulator-max-microvolt = <0x2dc6c0>;
+		phandle = <0x6d>;
+	};
+
+	vcc3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3";
+		regulator-min-microvolt = <0x325aa0>;
+		regulator-max-microvolt = <0x325aa0>;
+		phandle = <0x09>;
+	};
+
+	vcc5v0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0";
+		regulator-min-microvolt = <0x4c4b40>;
+		regulator-max-microvolt = <0x4c4b40>;
+		phandle = <0x6e>;
+	};
+
+	aliases {
+		ethernet0 = "/soc/ethernet@1c30000";
+		serial0 = "/soc/serial@1c28000";
+	};
+
+	connector {
+		compatible = "hdmi-connector";
+		type = [61 00];
+
+		port {
+
+			endpoint {
+				remote-endpoint = <0x32>;
+				phandle = <0x23>;
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pwr_led {
+			label = "orangepi:green:pwr";
+			gpios = <0x31 0x00 0x0a 0x00>;
+			default-state = "on";
+		};
+
+		status_led {
+			label = "orangepi:red:status";
+			gpios = <0x0a 0x00 0x0f 0x00>;
+		};
+	};
+
+	r_gpio_keys {
+		compatible = "gpio-keys";
+
+		sw4 {
+			label = "sw4";
+			linux,code = <0x74>;
+			gpios = <0x31 0x00 0x03 0x01>;
+		};
+	};
+
+	vdd-cpux-regulator {
+		compatible = "regulator-gpio";
+		regulator-name = "vdd-cpux";
+		regulator-type = "voltage";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <0x10c8e0>;
+		regulator-max-microvolt = <0x13d620>;
+		regulator-ramp-delay = <0x32>;
+		gpios = <0x31 0x00 0x06 0x00>;
+		enable-active-high;
+		gpios-states = <0x01>;
+		states = <0x10c8e0 0x00 0x13d620 0x01>;
+		phandle = <0x2a>;
+	};
+
+	__symbols__ {
+		osc24M = "/clocks/osc24M_clk";
+		osc32k = "/clocks/osc32k_clk";
+		cpu0_opp_table = "/opp_table0";
+		de = "/display-engine";
+		display_clocks = "/soc/clock@1000000";
+		mixer0 = "/soc/mixer@1100000";
+		mixer0_out = "/soc/mixer@1100000/ports/port@1";
+		mixer0_out_tcon0 = "/soc/mixer@1100000/ports/port@1/endpoint";
+		dma = "/soc/dma-controller@1c02000";
+		tcon0 = "/soc/lcd-controller@1c0c000";
+		tcon0_in = "/soc/lcd-controller@1c0c000/ports/port@0";
+		tcon0_in_mixer0 = "/soc/lcd-controller@1c0c000/ports/port@0/endpoint";
+		tcon0_out = "/soc/lcd-controller@1c0c000/ports/port@1";
+		tcon0_out_hdmi = "/soc/lcd-controller@1c0c000/ports/port@1/endpoint@1";
+		mmc0 = "/soc/mmc@1c0f000";
+		mmc1 = "/soc/mmc@1c10000";
+		mmc2 = "/soc/mmc@1c11000";
+		sid = "/soc/eeprom@1c14000";
+		ths_calibration = "/soc/eeprom@1c14000/thermal-sensor-calibration@34";
+		usb_otg = "/soc/usb@1c19000";
+		usbphy = "/soc/phy@1c19400";
+		ehci0 = "/soc/usb@1c1a000";
+		ohci0 = "/soc/usb@1c1a400";
+		ehci1 = "/soc/usb@1c1b000";
+		ohci1 = "/soc/usb@1c1b400";
+		ehci2 = "/soc/usb@1c1c000";
+		ohci2 = "/soc/usb@1c1c400";
+		ehci3 = "/soc/usb@1c1d000";
+		ohci3 = "/soc/usb@1c1d400";
+		ccu = "/soc/clock@1c20000";
+		pio = "/soc/pinctrl@1c20800";
+		csi_pins = "/soc/pinctrl@1c20800/csi-pins";
+		emac_rgmii_pins = "/soc/pinctrl@1c20800/emac-rgmii-pins";
+		i2c0_pins = "/soc/pinctrl@1c20800/i2c0-pins";
+		i2c1_pins = "/soc/pinctrl@1c20800/i2c1-pins";
+		i2c2_pins = "/soc/pinctrl@1c20800/i2c2-pins";
+		i2s0_pins = "/soc/pinctrl@1c20800/i2s0-pins";
+		i2s1_pins = "/soc/pinctrl@1c20800/i2s1-pins";
+		mmc0_pins = "/soc/pinctrl@1c20800/mmc0-pins";
+		mmc1_pins = "/soc/pinctrl@1c20800/mmc1-pins";
+		mmc2_8bit_pins = "/soc/pinctrl@1c20800/mmc2-8bit-pins";
+		spdif_tx_pin = "/soc/pinctrl@1c20800/spdif-tx-pin";
+		spi0_pins = "/soc/pinctrl@1c20800/spi0-pins";
+		spi1_pins = "/soc/pinctrl@1c20800/spi1-pins";
+		uart0_pa_pins = "/soc/pinctrl@1c20800/uart0-pa-pins";
+		uart1_pins = "/soc/pinctrl@1c20800/uart1-pins";
+		uart1_rts_cts_pins = "/soc/pinctrl@1c20800/uart1-rts-cts-pins";
+		uart2_pins = "/soc/pinctrl@1c20800/uart2-pins";
+		uart2_rts_cts_pins = "/soc/pinctrl@1c20800/uart2-rts-cts-pins";
+		uart3_pins = "/soc/pinctrl@1c20800/uart3-pins";
+		uart3_rts_cts_pins = "/soc/pinctrl@1c20800/uart3-rts-cts-pins";
+		emac = "/soc/ethernet@1c30000";
+		mdio = "/soc/ethernet@1c30000/mdio";
+		internal_mdio = "/soc/ethernet@1c30000/mdio-mux/mdio@1";
+		int_mii_phy = "/soc/ethernet@1c30000/mdio-mux/mdio@1/ethernet-phy@1";
+		external_mdio = "/soc/ethernet@1c30000/mdio-mux/mdio@2";
+		spi0 = "/soc/spi@1c68000";
+		spi1 = "/soc/spi@1c69000";
+		wdt0 = "/soc/watchdog@1c20ca0";
+		spdif = "/soc/spdif@1c21000";
+		pwm = "/soc/pwm@1c21400";
+		i2s0 = "/soc/i2s@1c22000";
+		i2s1 = "/soc/i2s@1c22400";
+		i2s2 = "/soc/i2s@1c22800";
+		sound_hdmi = "/soc/sound";
+		codec = "/soc/codec@1c22c00";
+		uart0 = "/soc/serial@1c28000";
+		uart1 = "/soc/serial@1c28400";
+		uart2 = "/soc/serial@1c28800";
+		uart3 = "/soc/serial@1c28c00";
+		i2c0 = "/soc/i2c@1c2ac00";
+		i2c1 = "/soc/i2c@1c2b000";
+		i2c2 = "/soc/i2c@1c2b400";
+		gic = "/soc/interrupt-controller@1c81000";
+		csi = "/soc/camera@1cb0000";
+		hdmi = "/soc/hdmi@1ee0000";
+		hdmi_in = "/soc/hdmi@1ee0000/ports/port@0";
+		hdmi_in_tcon0 = "/soc/hdmi@1ee0000/ports/port@0/endpoint";
+		hdmi_out = "/soc/hdmi@1ee0000/ports/port@1";
+		hdmi_out_con = "/soc/hdmi@1ee0000/ports/port@1/endpoint";
+		hdmi_phy = "/soc/hdmi-phy@1ef0000";
+		rtc = "/soc/rtc@1f00000";
+		r_ccu = "/soc/clock@1f01400";
+		codec_analog = "/soc/codec-analog@1f015c0";
+		ir = "/soc/ir@1f02000";
+		r_i2c = "/soc/i2c@1f02400";
+		r_pio = "/soc/pinctrl@1f02c00";
+		r_ir_rx_pin = "/soc/pinctrl@1f02c00/r-ir-rx-pin";
+		r_i2c_pins = "/soc/pinctrl@1f02c00/r-i2c-pins";
+		syscon = "/soc/system-control@1c00000";
+		sram_c = "/soc/system-control@1c00000/sram@1d00000";
+		ve_sram = "/soc/system-control@1c00000/sram@1d00000/sram-section@0";
+		mali = "/soc/gpu@1c40000";
+		ths = "/soc/ths@1c25000";
+		cpu0 = "/cpus/cpu@0";
+		cpu1 = "/cpus/cpu@1";
+		cpu2 = "/cpus/cpu@2";
+		cpu3 = "/cpus/cpu@3";
+		cpu_thermal = "/thermal-zones/cpu-thermal";
+		cpu_hot_trip = "/thermal-zones/cpu-thermal/trips/cpu-hot";
+		cpu_very_hot_trip = "/thermal-zones/cpu-thermal/trips/cpu-very-hot";
+		reg_ahci_5v = "/ahci-5v";
+		reg_usb0_vbus = "/usb0-vbus";
+		reg_usb1_vbus = "/usb1-vbus";
+		reg_usb2_vbus = "/usb2-vbus";
+		reg_vcc3v0 = "/vcc3v0";
+		reg_vcc3v3 = "/vcc3v3";
+		reg_vcc5v0 = "/vcc5v0";
+		hdmi_con_in = "/connector/port/endpoint";
+		reg_vdd_cpux = "/vdd-cpux-regulator";
+	};
+};


### PR DESCRIPTION
## :pushpin: Description

Some device tree configurations for the I2C adapter №0 and [Bosch Sensortec BME280 sensor](https://www.bosch-sensortec.com/products/environmental-sensors/humidity-sensors-bme280/). See [sources of I2C driver for Bosch Sensortec BME280 sensor](https://gitlab.com/malokhvii-eduard/bme280-driver).

## :page_with_curl: Booting process

```console
U-Boot SPL 2019.04-armbian (Nov 18 2019 - 23:02:49 +0100)
DRAM: 512 MiB
Trying to boot from MMC1


U-Boot 2019.04-armbian (Nov 18 2019 - 23:02:49 +0100) Allwinner Technology

CPU:   Allwinner H3 (SUN8I 1680)
Model: Xunlong Orange Pi One
DRAM:  512 MiB
MMC:   mmc@1c0f000: 0
Loading Environment from EXT4... ** File not found /boot/boot.env **

** Unable to read "/boot/boot.env" from mmc0:1 **
In:    serial
Out:   serial
Err:   serial
Net:   phy interface0
eth0: ethernet@1c30000
** Reading file would overwrite reserved memory **
There is no valid bmp file at the given address
starting USB...
USB0:   USB EHCI 1.00
USB1:   USB OHCI 1.0
USB2:   USB EHCI 1.00
USB3:   USB OHCI 1.0
scanning bus 0 for devices... 1 USB Device(s) found
scanning bus 1 for devices... 1 USB Device(s) found
scanning bus 2 for devices... 1 USB Device(s) found
scanning bus 3 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Autoboot in 1 seconds, press <Space> to stop
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot/boot.scr
3798 bytes read in 2 ms (1.8 MiB/s)
## Executing script at 43100000
U-boot loaded from SD
Boot script loaded from mmc
222 bytes read in 1 ms (216.8 KiB/s)
7307841 bytes read in 352 ms (19.8 MiB/s)
7644632 bytes read in 369 ms (19.8 MiB/s)
Found mainline kernel configuration
28283 bytes read in 9 ms (3 MiB/s)
374 bytes read in 3 ms (121.1 KiB/s)
Applying kernel provided DT overlay sun8i-h3-i2c0.dtbo
508 bytes read in 5 ms (98.6 KiB/s)
Applying kernel provided DT overlay sun8i-h3-bme280.dtbo
4155 bytes read in 4 ms (1013.7 KiB/s)
Applying kernel provided DT fixup script (sun8i-h3-fixup.scr)
## Executing script at 44000000
## Loading init Ramdisk from Legacy Image at 43300000 ...
   Image Name:   uInitrd
   Image Type:   ARM Linux RAMDisk Image (gzip compressed)
   Data Size:    7307777 Bytes = 7 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 43000000
   Booting using the fdt blob at 0x43000000
EHCI failed to shut down host controller.
   Loading Ramdisk to 49907000, end 49fff201 ... OK
   Loading Device Tree to 49897000, end 49906fff ... OK

Starting kernel ...

Uncompressing Linux... done, booting the kernel.
```

## :page_with_curl: Output of dmesg

```console
$ dmesg
[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 5.3.9-sunxi (root@builder) (gcc version 8.3.0 (GNU Toolchain for the A-profile Architecture 8.3-2019.03 (arm-rel-8.36))) #19.11.3 SMP Mon Nov 18 18:49:43 CET 2019
[    0.000000] CPU: ARMv7 Processor [410fc075] revision 5 (ARMv7), cr=50c5387d
[    0.000000] CPU: div instructions available: patching division code
[    0.000000] CPU: PIPT / VIPT nonaliasing data cache, VIPT aliasing instruction cache
[    0.000000] OF: fdt: Machine model: Xunlong Orange Pi One
[    0.000000] Memory policy: Data cache writealloc
[    0.000000] cma: Reserved 128 MiB at 0x55c00000
[    0.000000] On node 0 totalpages: 131072
[    0.000000]   Normal zone: 1152 pages used for memmap
[    0.000000]   Normal zone: 0 pages reserved
[    0.000000]   Normal zone: 131072 pages, LIFO batch:31
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: Using PSCI v0.1 Function IDs from DT
[    0.000000] percpu: Embedded 20 pages/cpu s49676 r8192 d24052 u81920
[    0.000000] pcpu-alloc: s49676 r8192 d24052 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 129920
[    0.000000] Kernel command line: root=UUID=24819d8b-5022-4647-a64d-eb65eea3ea11 rootwait rootfstype=ext4 console=ttyS0,115200 console=tty1 hdmi.audio=EDID:0 disp.screen0_output_mode=1920x1080p60 panic=10 consoleblank=0 loglevel=1 ubootpart=7d2a55ce-01 ubootsource=mmc usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u   sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16 cgroup_enable=memory swapaccount=1
[    0.000000] Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] allocated 524288 bytes of page_ext
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 363696K/524288K available (9216K kernel code, 1040K rwdata, 2772K rodata, 1024K init, 316K bss, 29520K reserved, 131072K cma-reserved, 0K highmem)
[    0.000000] random: get_random_u32 called from __kmem_cache_create+0x2b/0x3ac with crng_init=0
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] ftrace: allocating 40210 entries in 79 pages
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=4.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
[    0.000000] GIC: Using split EOI/Deactivate mode
[    0.000000] clocksource: timer: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 79635851949 ns
[    0.000000] arch_timer: cp15 timer(s) running at 24.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000006] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 4398046511097ns
[    0.000014] Switching to timer-based delay loop, resolution 41ns
[    0.000182] Console: colour dummy device 80x30
[    0.000194] printk: console [tty1] enabled
[    0.000237] Calibrating delay loop (skipped), value calculated using timer frequency.. 48.00 BogoMIPS (lpj=96000)
[    0.000247] pid_max: default: 32768 minimum: 301
[    0.000486] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.000495] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.001157] *** VALIDATE proc ***
[    0.001415] *** VALIDATE cgroup1 ***
[    0.001422] *** VALIDATE cgroup2 ***
[    0.001476] CPU: Testing write buffer coherency: ok
[    0.001843] CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
[    0.002310] Setting up static identity map for 0x40100000 - 0x40100054
[    0.002413] rcu: Hierarchical SRCU implementation.
[    0.002908] smp: Bringing up secondary CPUs ...
[    0.013589] CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
[    0.024380] CPU2: thread -1, cpu 2, socket 0, mpidr 80000002
[    0.035097] CPU3: thread -1, cpu 3, socket 0, mpidr 80000003
[    0.035189] smp: Brought up 1 node, 4 CPUs
[    0.035197] SMP: Total of 4 processors activated (192.00 BogoMIPS).
[    0.035200] CPU: All CPU(s) started in HYP mode.
[    0.035202] CPU: Virtualization extensions available.
[    0.036164] devtmpfs: initialized
[    0.042185] VFP support v0.3: implementor 41 architecture 2 part 30 variant 7 rev 5
[    0.042407] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.042424] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.046983] xor: measuring software checksum speed
[    0.087032]    arm4regs  :  1255.000 MB/sec
[    0.127083]    8regs     :   874.000 MB/sec
[    0.167140]    32regs    :   826.000 MB/sec
[    0.207192]    neon      :  1271.000 MB/sec
[    0.207196] xor: using function: neon (1271.000 MB/sec)
[    0.207258] pinctrl core: initialized pinctrl subsystem
[    0.208232] NET: Registered protocol family 16
[    0.209905] DMA: preallocated 256 KiB pool for atomic coherent allocations
[    0.210425] audit: initializing netlink subsys (disabled)
[    0.210620] audit: type=2000 audit(0.184:1): state=initialized audit_enabled=0 res=1
[    0.211040] cpuidle: using governor ladder
[    0.211070] cpuidle: using governor menu
[    0.211591] hw-breakpoint: found 5 (+1 reserved) breakpoint and 4 watchpoint registers.
[    0.211595] hw-breakpoint: maximum watchpoint size is 8 bytes.
[    0.303447] raid6: neonx8   gen()   709 MB/s
[    0.371518] raid6: neonx8   xor()   590 MB/s
[    0.439594] raid6: neonx4   gen()   727 MB/s
[    0.507699] raid6: neonx4   xor()   616 MB/s
[    0.575771] raid6: neonx2   gen()   663 MB/s
[    0.643809] raid6: neonx2   xor()   584 MB/s
[    0.711977] raid6: neonx1   gen()   495 MB/s
[    0.780033] raid6: neonx1   xor()   467 MB/s
[    0.848084] raid6: int32x8  gen()   267 MB/s
[    0.916221] raid6: int32x8  xor()   174 MB/s
[    0.984242] raid6: int32x4  gen()   285 MB/s
[    1.052330] raid6: int32x4  xor()   195 MB/s
[    1.120564] raid6: int32x2  gen()   255 MB/s
[    1.188504] raid6: int32x2  xor()   206 MB/s
[    1.256748] raid6: int32x1  gen()   200 MB/s
[    1.324812] raid6: int32x1  xor()   176 MB/s
[    1.324816] raid6: using algorithm neonx4 gen() 727 MB/s
[    1.324819] raid6: .... xor() 616 MB/s, rmw enabled
[    1.324823] raid6: using neon recovery algorithm
[    1.326403] SCSI subsystem initialized
[    1.326623] libata version 3.00 loaded.
[    1.326828] usbcore: registered new interface driver usbfs
[    1.326868] usbcore: registered new interface driver hub
[    1.326944] usbcore: registered new device driver usb
[    1.327111] mc: Linux media interface: v0.10
[    1.327138] videodev: Linux video capture interface: v2.00
[    1.327281] pps_core: LinuxPPS API ver. 1 registered
[    1.327285] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[    1.327300] PTP clock support registered
[    1.328746] clocksource: Switched to clocksource arch_sys_counter
[    2.149005] VFS: Disk quotas dquot_6.6.0
[    2.149086] VFS: Dquot-cache hash table entries: 1024 (order 0, 4096 bytes)
[    2.156432] thermal_sys: Registered thermal governor 'fair_share'
[    2.156438] thermal_sys: Registered thermal governor 'bang_bang'
[    2.156444] thermal_sys: Registered thermal governor 'step_wise'
[    2.156447] thermal_sys: Registered thermal governor 'power_allocator'
[    2.156951] NET: Registered protocol family 2
[    2.157582] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
[    2.157610] TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    2.157649] TCP bind hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    2.157707] TCP: Hash tables configured (established 4096 bind 4096)
[    2.157798] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    2.157831] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    2.158021] NET: Registered protocol family 1
[    2.158498] RPC: Registered named UNIX socket transport module.
[    2.158503] RPC: Registered udp transport module.
[    2.158507] RPC: Registered tcp transport module.
[    2.158510] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    2.158724] Trying to unpack rootfs image as initramfs...
[    2.588353] Freeing initrd memory: 7140K
[    2.590147] Initialise system trusted keyrings
[    2.590381] workingset: timestamp_bits=14 max_order=17 bucket_order=3
[    2.596587] zbud: loaded
[    2.598905] NFS: Registering the id_resolver key type
[    2.598936] Key type id_resolver registered
[    2.598939] Key type id_legacy registered
[    2.598951] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    2.598956] Installing knfsd (copyright (C) 1996 okir@monad.swb.de).
[    2.600308] JFS: nTxBlock = 3921, nTxLock = 31369
[    2.604994] SGI XFS with ACLs, security attributes, realtime, no debug enabled
[    2.656422] Key type asymmetric registered
[    2.656431] Asymmetric key parser 'x509' registered
[    2.656502] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
[    2.656701] io scheduler mq-deadline registered
[    2.656707] io scheduler kyber registered
[    2.656944] io scheduler bfq registered
[    2.661870] sun8i-h3-pinctrl 1c20800.pinctrl: initialized sunXi PIO driver
[    2.663346] sun8i-h3-r-pinctrl 1f02c00.pinctrl: initialized sunXi PIO driver
[    2.668897] Serial: 8250/16550 driver, 8 ports, IRQ sharing disabled
[    2.670385] sun8i-h3-pinctrl 1c20800.pinctrl: 1c20800.pinctrl supply vcc-pa not found, using dummy regulator
[    2.670774] printk: console [ttyS0] disabled
[    2.690951] 1c28000.serial: ttyS0 at MMIO 0x1c28000 (irq = 36, base_baud = 1500000) is a U6_16550A
[    2.691003] printk: console [ttyS0] enabled
[    2.705560] sun4i-drm display-engine: bound 1100000.mixer (ops 0xc0a8c638)
[    2.705826] sun4i-drm display-engine: bound 1c0c000.lcd-controller (ops 0xc0a89220)
[    2.705890] sun8i-dw-hdmi 1ee0000.hdmi: 1ee0000.hdmi supply hvcc not found, using dummy regulator
[    2.706763] sun8i-dw-hdmi 1ee0000.hdmi: Detected HDMI TX controller v1.32a with HDCP (sun8i_dw_hdmi_phy)
[    2.707153] sun8i-dw-hdmi 1ee0000.hdmi: registered DesignWare HDMI I2C bus driver
[    2.707395] sun4i-drm display-engine: bound 1ee0000.hdmi (ops 0xc0a8bc24)
[    2.707401] [drm] Supports vblank timestamp caching Rev 2 (21.10.2013).
[    2.707405] [drm] No driver support for vblank timestamp query.
[    2.707755] [drm] Initialized sun4i-drm 1.0.0 20150629 for display-engine on minor 0
[    2.707826] [drm] Cannot find any crtc or sizes
[    2.708553] [drm] Cannot find any crtc or sizes
[    2.710929] brd: module loaded
[    2.716366] loop: module loaded
[    2.718356] libphy: Fixed MDIO Bus: probed
[    2.718842] dwmac-sun8i 1c30000.ethernet: PTP uses main clock
[    2.718887] dwmac-sun8i 1c30000.ethernet: 1c30000.ethernet supply phy not found, using dummy regulator
[    2.718959] dwmac-sun8i 1c30000.ethernet: 1c30000.ethernet supply phy-io not found, using dummy regulator
[    2.719297] dwmac-sun8i 1c30000.ethernet: Current syscon value is not the default 148000 (expect 58000)
[    2.719317] dwmac-sun8i 1c30000.ethernet: No HW DMA feature register supported
[    2.719323] dwmac-sun8i 1c30000.ethernet: RX Checksum Offload Engine supported
[    2.719329] dwmac-sun8i 1c30000.ethernet: COE Type 2
[    2.719335] dwmac-sun8i 1c30000.ethernet: TX Checksum insertion supported
[    2.719341] dwmac-sun8i 1c30000.ethernet: Normal descriptors
[    2.719346] dwmac-sun8i 1c30000.ethernet: Chain mode enabled
[    2.719483] libphy: stmmac: probed
[    2.719940] dwmac-sun8i 1c30000.ethernet: Found internal PHY node
[    2.720040] libphy: mdio_mux: probed
[    2.720058] dwmac-sun8i 1c30000.ethernet: Switch mux to internal PHY
[    2.720066] dwmac-sun8i 1c30000.ethernet: Powering internal PHY
[    2.730735] libphy: mdio_mux: probed
[    2.731586] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    2.731591] ehci-platform: EHCI generic platform driver
[    2.731778] ehci-platform 1c1a000.usb: EHCI Host Controller
[    2.731805] ehci-platform 1c1a000.usb: new USB bus registered, assigned bus number 1
[    2.732206] ehci-platform 1c1a000.usb: irq 26, io mem 0x01c1a000
[    2.744748] ehci-platform 1c1a000.usb: USB 2.0 started, EHCI 1.00
[    2.745011] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.03
[    2.745019] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    2.745025] usb usb1: Product: EHCI Host Controller
[    2.745031] usb usb1: Manufacturer: Linux 5.3.9-sunxi ehci_hcd
[    2.745037] usb usb1: SerialNumber: 1c1a000.usb
[    2.745567] hub 1-0:1.0: USB hub found
[    2.745615] hub 1-0:1.0: 1 port detected
[    2.746225] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    2.746248] ohci-platform: OHCI generic platform driver
[    2.746401] ohci-platform 1c1a400.usb: Generic Platform OHCI controller
[    2.746422] ohci-platform 1c1a400.usb: new USB bus registered, assigned bus number 2
[    2.746613] ohci-platform 1c1a400.usb: irq 27, io mem 0x01c1a400
[    2.808989] usb usb2: New USB device found, idVendor=1d6b, idProduct=0001, bcdDevice= 5.03
[    2.808998] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    2.809004] usb usb2: Product: Generic Platform OHCI controller
[    2.809010] usb usb2: Manufacturer: Linux 5.3.9-sunxi ohci_hcd
[    2.809016] usb usb2: SerialNumber: 1c1a400.usb
[    2.809500] hub 2-0:1.0: USB hub found
[    2.809548] hub 2-0:1.0: 1 port detected
[    2.810527] usbcore: registered new interface driver usb-storage
[    2.811362] sun6i-rtc 1f00000.rtc: registered as rtc0
[    2.811368] sun6i-rtc 1f00000.rtc: RTC enabled
[    2.811597] i2c /dev entries driver
[    2.813570] sunxi-wdt 1c20ca0.watchdog: Watchdog enabled (timeout=16 sec, nowayout=0)
[    2.814176] sun8i-h3-pinctrl 1c20800.pinctrl: 1c20800.pinctrl supply vcc-pf not found, using dummy regulator
[    2.814896] sunxi-mmc 1c0f000.mmc: Got CD GPIO
[    2.840197] sunxi-mmc 1c0f000.mmc: initialized, max. request size: 16384 KB
[    2.840627] sun8i-h3-r-pinctrl 1f02c00.pinctrl: 1f02c00.pinctrl supply vcc-pl not found, using dummy regulator
[    2.841280] ledtrig-cpu: registered to indicate activity on CPUs
[    2.841344] hidraw: raw HID events driver (C) Jiri Kosina
[    2.841462] usbcore: registered new interface driver usbhid
[    2.841465] usbhid: USB HID core driver
[    2.843711] Initializing XFRM netlink socket
[    2.844360] NET: Registered protocol family 10
[    2.876818] mmc0: host does not support reading read-only switch, assuming write-enable
[    2.879561] mmc0: new high speed SDHC card at address aaaa
[    2.880992] mmcblk0: mmc0:aaaa SC16G 14.8 GiB 
[    2.883808]  mmcblk0: p1
[    2.905310] Segment Routing with IPv6
[    2.905420] NET: Registered protocol family 17
[    2.905450] NET: Registered protocol family 15
[    2.905521] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
[    2.905713] 8021q: 802.1Q VLAN Support v1.8
[    2.905776] Key type dns_resolver registered
[    2.906220] Registering SWP/SWPB emulation handler
[    2.906764] registered taskstats version 1
[    2.906768] Loading compiled-in X.509 certificates
[    2.906859] zswap: loaded using pool lzo/zbud
[    2.909439] Btrfs loaded, crc32c=crc32c-generic
[    2.938845] Key type encrypted registered
[    2.948332] sun8i-h3-pinctrl 1c20800.pinctrl: 1c20800.pinctrl supply vcc-pg not found, using dummy regulator
[    2.949666] ehci-platform 1c1b000.usb: EHCI Host Controller
[    2.949701] ehci-platform 1c1b000.usb: new USB bus registered, assigned bus number 3
[    2.950021] ehci-platform 1c1b000.usb: irq 28, io mem 0x01c1b000
[    2.964771] ehci-platform 1c1b000.usb: USB 2.0 started, EHCI 1.00
[    2.964977] usb usb3: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.03
[    2.964985] usb usb3: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    2.964992] usb usb3: Product: EHCI Host Controller
[    2.964998] usb usb3: Manufacturer: Linux 5.3.9-sunxi ehci_hcd
[    2.965004] usb usb3: SerialNumber: 1c1b000.usb
[    2.965546] hub 3-0:1.0: USB hub found
[    2.965583] hub 3-0:1.0: 1 port detected
[    2.966358] ohci-platform 1c1b400.usb: Generic Platform OHCI controller
[    2.966380] ohci-platform 1c1b400.usb: new USB bus registered, assigned bus number 4
[    2.966589] ohci-platform 1c1b400.usb: irq 29, io mem 0x01c1b400
[    3.028932] usb usb4: New USB device found, idVendor=1d6b, idProduct=0001, bcdDevice= 5.03
[    3.028940] usb usb4: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    3.028946] usb usb4: Product: Generic Platform OHCI controller
[    3.028952] usb usb4: Manufacturer: Linux 5.3.9-sunxi ohci_hcd
[    3.028958] usb usb4: SerialNumber: 1c1b400.usb
[    3.029408] hub 4-0:1.0: USB hub found
[    3.029452] hub 4-0:1.0: 1 port detected
[    3.030238] usb_phy_generic usb_phy_generic.2.auto: usb_phy_generic.2.auto supply vcc not found, using dummy regulator
[    3.030626] musb-hdrc musb-hdrc.3.auto: MUSB HDRC host driver
[    3.030637] musb-hdrc musb-hdrc.3.auto: new USB bus registered, assigned bus number 5
[    3.030843] usb usb5: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 5.03
[    3.030851] usb usb5: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    3.030858] usb usb5: Product: MUSB HDRC host driver
[    3.030864] usb usb5: Manufacturer: Linux 5.3.9-sunxi musb-hcd
[    3.030870] usb usb5: SerialNumber: musb-hdrc.3.auto
[    3.031305] hub 5-0:1.0: USB hub found
[    3.031341] hub 5-0:1.0: 1 port detected
[    3.032216] sun6i-rtc 1f00000.rtc: setting system clock to 2020-02-10T12:28:00 UTC (1581337680)
[    3.032399] of_cfs_init
[    3.032515] of_cfs_init: OK
[    3.035879] Freeing unused kernel memory: 1024K
[    3.044964] Run /init as init process
[    3.328827] input: r_gpio_keys as /devices/platform/r_gpio_keys/input/input0
[    3.849851] random: fast init done
[    3.869641] EXT4-fs (mmcblk0p1): mounted filesystem with writeback data mode. Opts: (null)
[    4.576465] systemd[1]: systemd 241 running in system mode. (+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid)
[    4.577161] systemd[1]: Detected architecture arm.
[    4.596322] systemd[1]: Set hostname to <chlorine>.
[    4.602407] systemd[1]: Failed to bump fs.file-max, ignoring: Invalid argument
[    5.213529] random: systemd: uninitialized urandom read (16 bytes read)
[    5.225264] random: systemd: uninitialized urandom read (16 bytes read)
[    5.225346] systemd[1]: Reached target System Time Synchronized.
[    5.226048] random: systemd: uninitialized urandom read (16 bytes read)
[    5.229052] systemd[1]: Created slice User and Session Slice.
[    5.230353] systemd[1]: Set up automount Arbitrary Executable File Formats File System Automount Point.
[    5.230743] systemd[1]: Reached target Remote File Systems.
[    5.231257] systemd[1]: Listening on initctl Compatibility Named Pipe.
[    5.232223] systemd[1]: Listening on Journal Audit Socket.
[    5.376960] bme280: loading out-of-tree module taints kernel.
[    5.396826] bme280: register device at i2c-0 0x76
[    5.413628] EXT4-fs (mmcblk0p1): re-mounted. Opts: commit=600,errors=remount-ro
[    5.774209] systemd-journald[279]: Received request to flush runtime journal from PID 1
[    6.000343] core: _opp_supported_by_regulators: OPP minuV: 1320000 maxuV: 1320000, not supported by regulator
[    6.000367] cpu cpu0: _opp_add: OPP not supported by regulators (1104000000)
[    6.000547] core: _opp_supported_by_regulators: OPP minuV: 1320000 maxuV: 1320000, not supported by regulator
[    6.000562] cpu cpu0: _opp_add: OPP not supported by regulators (1200000000)
[    6.000698] core: _opp_supported_by_regulators: OPP minuV: 1340000 maxuV: 1340000, not supported by regulator
[    6.000709] cpu cpu0: _opp_add: OPP not supported by regulators (1296000000)
[    6.000923] core: _opp_supported_by_regulators: OPP minuV: 1400000 maxuV: 1400000, not supported by regulator
[    6.000935] cpu cpu0: _opp_add: OPP not supported by regulators (1368000000)
[    6.271567] lima 1c40000.gpu: gp - mali400 version major 1 minor 1
[    6.271629] lima 1c40000.gpu: pp0 - mali400 version major 1 minor 1
[    6.271687] lima 1c40000.gpu: pp1 - mali400 version major 1 minor 1
[    6.271762] lima 1c40000.gpu: l2 cache 64K, 4-way, 64byte cache line, 64bit external bus
[    6.288615] lima 1c40000.gpu: bus rate = 200000000
[    6.288639] lima 1c40000.gpu: mod rate = 384000000
[    6.296034] [drm] Initialized lima 1.0.0 20190217 for 1c40000.gpu on minor 1
[    6.437145] zram: Added device: zram0
[    6.439391] zram: Added device: zram1
[    6.443724] zram: Added device: zram2
[    6.551471] zram1: detected capacity change from 0 to 257503232
[    6.632925] asoc-simple-card soc:sound: i2s-hifi <-> 1c22800.i2s mapping ok
[    7.632774] Adding 251464k swap on /dev/zram1.  Priority:5 extents:1 across:251464k SSFS
[    7.789616] zram0: detected capacity change from 0 to 52428800
[    8.175031] random: crng init done
[    8.175044] random: 7 urandom warning(s) missed due to ratelimiting
[    8.384240] EXT4-fs (zram0): mounted filesystem without journal. Opts: discard
[   15.137913] dwmac-sun8i 1c30000.ethernet eth0: PHY [0.1:01] driver [Generic PHY]
[   15.137934] dwmac-sun8i 1c30000.ethernet eth0: phy: setting supported 00,00000000,000062cf advertising 00,00000000,000062cf
[   15.141377] dwmac-sun8i 1c30000.ethernet eth0: No Safety Features support found
[   15.141395] dwmac-sun8i 1c30000.ethernet eth0: No MAC Management Counters available
[   15.141405] dwmac-sun8i 1c30000.ethernet eth0: PTP not supported by HW
[   15.141430] dwmac-sun8i 1c30000.ethernet eth0: configuring for phy/mii link mode
[   15.141454] dwmac-sun8i 1c30000.ethernet eth0: phylink_mac_config: mode=phy/mii/Unknown/Unknown adv=00,00000000,000062cf pause=10 link=0 an=1
[   15.146720] dwmac-sun8i 1c30000.ethernet eth0: phy link up mii/100Mbps/Full
[   15.146766] dwmac-sun8i 1c30000.ethernet eth0: phylink_mac_config: mode=phy/mii/100Mbps/Full adv=00,00000000,00000000 pause=0e link=1 an=0
[   15.146786] dwmac-sun8i 1c30000.ethernet eth0: Link is Up - 100Mbps/Full - flow control rx/tx
[   15.146812] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[   33.782314] vcc3v0: disabling
[   33.782334] vcc5v0: disabling
[   33.782343] usb0-vbus: disabling
```

## :partly_sunny: Bosch Sensortec BME280 sensor information as table

```console
$ cat /proc/bme280info
I2C Adapter              : i2c-0
I2C Address              : 0x76

Chip Id                  : 0x60
Power Mode               : 0x0
Pressure Oversampling    : 0x5
Temperature Oversampling : 0x2
Humidity Oversampling    : 0x1
Filter Coefficient       : 0x4
Standby Time             : 0x0

Pressure                 : 75192
Temperature              : 2017
Humidity                 : 63985
```