### PR TITLE
memory: kernel module

### DIFF
--- a/memory/Makefile
+++ b/memory/Makefile
@@ -18,5 +18,5 @@ uninstall:
 	lsmod | head -n 3
 format:
 	clang-format-9 -i kernel_memory.c
-#./checkpatch.pl --no-tree -f ./kernel_memory.c
+#	 ./checkpatch.pl --no-tree -f ./kernel_memory.c
 endif

--- a/memory/Makefile
+++ b/memory/Makefile
@@ -1,0 +1,22 @@
+ifneq ($(KERNELRELEASE),)
+
+obj-m += kernel_memory.o
+
+else
+
+.PHONY: all clean install uninstall format
+
+all:
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) modules
+clean:
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(CURDIR) clean
+install:
+	sudo insmod kernel_memory.ko
+	lsmod | head -n 3
+uninstall:
+	sudo rmmod kernel_memory.ko
+	lsmod | head -n 3
+format:
+	clang-format-9 -i kernel_memory.c
+#./checkpatch.pl --no-tree -f ./kernel_memory.c
+endif

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,22 @@
+# Memory management
+
+## Homework
+1. Create user-space C or C++ program which tries to allocate buffers
+  with sizes 2^x for x in range from 0 to maximium possible value 
+  using functions:
+  **malloc, calloc, alloca, (optional for C++) new **.
+  Measure time of each allocation/freeing.
+  2^x means x power of 2 in this task.
+Pull request should contains program source code and program output
+in text format.
+
+2. Create kernel module and test allocation/freeing time for functions:
+  **kmalloc, kzmalloc, vmalloc, get_free_pages,
+   (optional and only for drivers integrated to kernel)alloc_bootmem**.
+  Measure the time of each allocation/freeing except alloc_bootmem.
+  The results should be presented in text file table with followed columns:
+  Buffer size, allocation time, freeing time.
+  Size unit is 1 byte, time unit is 1 ns.
+
+Pull request should contains source code of developed driver, Makefile
+and program output from system log in text format.

--- a/memory/kernel_memory.c
+++ b/memory/kernel_memory.c
@@ -9,16 +9,38 @@
 
 #define BUFF_SIZE 1024
 
+static size_t alloc_size;
 static struct hrtimer hr_timer;
 static ktime_t kt1;
 static ktime_t kt2;
 static ktime_t alloc_time;
 
+static ssize_t alloc_size_show(struct class *class,
+			       struct class_attribute *attr, char *buffer);
+static ssize_t alloc_size_store(struct class *class,
+				struct class_attribute *attr,
+				const char *buffer, size_t count);
 static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
 			    char *buffer);
 
 static struct class *class_alloc;
+CLASS_ATTR_RW(alloc_size);
 CLASS_ATTR_RO(kmalloc);
+
+static ssize_t alloc_size_show(struct class *class,
+			       struct class_attribute *attr, char *buffer)
+{
+	sprintf(buffer, "%lu\n", alloc_size);
+	return strlen(buffer);
+}
+
+static ssize_t alloc_size_store(struct class *class,
+				struct class_attribute *attr,
+				const char *buffer, size_t count)
+{
+	sscanf(buffer, "%lu\n", &alloc_size);
+	return count;
+}
 
 static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
 			    char *buffer)
@@ -26,17 +48,17 @@ static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
 	void *pdata;
 
 	kt1 = hrtimer_cb_get_time(&hr_timer);
-	pdata = kmalloc(BUFF_SIZE, GFP_KERNEL);
+	pdata = kmalloc(alloc_size, GFP_KERNEL);
 	kt2 = hrtimer_cb_get_time(&hr_timer);
 	if (!pdata) {
-		printk(KERN_WARNING "alloc-test: bad kmalloc: %d\n", ENOMEM);
+		printk(KERN_WARNING "kernel_memory: bad kmalloc: %d\n", ENOMEM);
 		return strlen(buffer);
 	}
 	alloc_time = kt2 - kt1;
 	kt1 = hrtimer_cb_get_time(&hr_timer);
 	kfree(pdata);
 	kt2 = hrtimer_cb_get_time(&hr_timer);
-	sprintf(buffer, "%-20llu%-20llu\n", alloc_time, (kt2 - kt1));
+	sprintf(buffer, "%llu %llu\n", alloc_time, (kt2 - kt1));
 
 	return strlen(buffer);
 }
@@ -44,18 +66,27 @@ static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
 static int __init kernel_memory_init(void)
 {
 	int ret;
+	alloc_size = BUFF_SIZE;
 
-	class_alloc = class_create(THIS_MODULE, "alloc-test");
+	class_alloc = class_create(THIS_MODULE, "alloc_test");
 	if (IS_ERR(class_alloc)) {
 		ret = PTR_ERR(class_alloc);
-		printk(KERN_ERR "alloc-test: bad create sysfs class: %d\n",
+		printk(KERN_ERR "kernel_memory: bad create sysfs class: %d\n",
+		       ret);
+		return ret;
+	}
+
+	class_attr_alloc_size.attr.mode = (S_IWUGO | S_IRUGO);
+	ret = class_create_file(class_alloc, &class_attr_alloc_size);
+	if (ret) {
+		printk(KERN_ERR "kernel_memory: bad size attr create: %d\n",
 		       ret);
 		return ret;
 	}
 
 	ret = class_create_file(class_alloc, &class_attr_kmalloc);
 	if (ret) {
-		printk(KERN_ERR "alloc-test: bad kmalloc attr create: %d\n",
+		printk(KERN_ERR "kernel_memory: bad kmalloc attr create: %d\n",
 		       ret);
 		return ret;
 	}
@@ -63,20 +94,21 @@ static int __init kernel_memory_init(void)
 	hrtimer_init(&hr_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 	hrtimer_start(&hr_timer, KTIME_MAX, HRTIMER_MODE_REL);
 
-	printk(KERN_INFO "alloc-test: module loaded\n");
+	printk(KERN_INFO "kernel_memory: module loaded\n");
 	return 0;
 }
 
 static void __exit kernel_memory_exit(void)
 {
 	if (class_alloc) {
+		class_remove_file(class_alloc, &class_attr_alloc_size);
 		class_remove_file(class_alloc, &class_attr_kmalloc);
 	}
 	class_destroy(class_alloc);
 
 	hrtimer_cancel(&hr_timer);
 
-	printk(KERN_INFO "alloc-test: module unloaded\n");
+	printk(KERN_INFO "kernel_memory: module unloaded\n");
 }
 
 module_init(kernel_memory_init);

--- a/memory/kernel_memory.c
+++ b/memory/kernel_memory.c
@@ -1,0 +1,88 @@
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/slab.h>
+#include <linux/hrtimer.h>
+#include <linux/ktime.h>
+#include <asm/uaccess.h>
+
+#define BUFF_SIZE 1024
+
+static struct hrtimer hr_timer;
+static ktime_t kt1;
+static ktime_t kt2;
+static ktime_t alloc_time;
+
+static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
+			    char *buffer);
+
+static struct class *class_alloc;
+CLASS_ATTR_RO(kmalloc);
+
+static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
+			    char *buffer)
+{
+	void *pdata;
+
+	kt1 = hrtimer_cb_get_time(&hr_timer);
+	pdata = kmalloc(BUFF_SIZE, GFP_KERNEL);
+	kt2 = hrtimer_cb_get_time(&hr_timer);
+	if (!pdata) {
+		printk(KERN_WARNING "alloc-test: bad kmalloc: %d\n", ENOMEM);
+		return strlen(buffer);
+	}
+	alloc_time = kt2 - kt1;
+	kt1 = hrtimer_cb_get_time(&hr_timer);
+	kfree(pdata);
+	kt2 = hrtimer_cb_get_time(&hr_timer);
+	sprintf(buffer, "%-20llu%-20llu\n", alloc_time, (kt2 - kt1));
+
+	return strlen(buffer);
+}
+
+static int __init kernel_memory_init(void)
+{
+	int ret;
+
+	class_alloc = class_create(THIS_MODULE, "alloc-test");
+	if (IS_ERR(class_alloc)) {
+		ret = PTR_ERR(class_alloc);
+		printk(KERN_ERR "alloc-test: bad create sysfs class: %d\n",
+		       ret);
+		return ret;
+	}
+
+	ret = class_create_file(class_alloc, &class_attr_kmalloc);
+	if (ret) {
+		printk(KERN_ERR "alloc-test: bad kmalloc attr create: %d\n",
+		       ret);
+		return ret;
+	}
+
+	hrtimer_init(&hr_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+	hrtimer_start(&hr_timer, KTIME_MAX, HRTIMER_MODE_REL);
+
+	printk(KERN_INFO "alloc-test: module loaded\n");
+	return 0;
+}
+
+static void __exit kernel_memory_exit(void)
+{
+	if (class_alloc) {
+		class_remove_file(class_alloc, &class_attr_kmalloc);
+	}
+	class_destroy(class_alloc);
+
+	hrtimer_cancel(&hr_timer);
+
+	printk(KERN_INFO "alloc-test: module unloaded\n");
+}
+
+module_init(kernel_memory_init);
+module_exit(kernel_memory_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Matvii Zorin");
+MODULE_DESCRIPTION("memory allocate/freeing test");
+MODULE_VERSION("0.1");

--- a/memory/kernel_memory.c
+++ b/memory/kernel_memory.c
@@ -22,10 +22,13 @@ static ssize_t alloc_size_store(struct class *class,
 				const char *buffer, size_t count);
 static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
 			    char *buffer);
+static ssize_t vmalloc_show(struct class *class, struct class_attribute *attr,
+			    char *buffer);
 
 static struct class *class_alloc;
 CLASS_ATTR_RW(alloc_size);
 CLASS_ATTR_RO(kmalloc);
+CLASS_ATTR_RO(vmalloc);
 
 static ssize_t alloc_size_show(struct class *class,
 			       struct class_attribute *attr, char *buffer)
@@ -63,6 +66,27 @@ static ssize_t kmalloc_show(struct class *class, struct class_attribute *attr,
 	return strlen(buffer);
 }
 
+static ssize_t vmalloc_show(struct class *class, struct class_attribute *attr,
+			    char *buffer)
+{
+	void *pdata;
+
+	kt1 = hrtimer_cb_get_time(&hr_timer);
+	pdata = vmalloc(alloc_size);
+	kt2 = hrtimer_cb_get_time(&hr_timer);
+	if (!pdata) {
+		printk(KERN_WARNING "kernel_memory: bad vmalloc: %d\n", ENOMEM);
+		return strlen(buffer);
+	}
+	alloc_time = kt2 - kt1;
+	kt1 = hrtimer_cb_get_time(&hr_timer);
+	vfree(pdata);
+	kt2 = hrtimer_cb_get_time(&hr_timer);
+	sprintf(buffer, "%llu %llu\n", alloc_time, (kt2 - kt1));
+
+	return strlen(buffer);
+}
+
 static int __init kernel_memory_init(void)
 {
 	int ret;
@@ -91,6 +115,13 @@ static int __init kernel_memory_init(void)
 		return ret;
 	}
 
+	ret = class_create_file(class_alloc, &class_attr_vmalloc);
+	if (ret) {
+		printk(KERN_ERR "kernel_memory: bad vmalloc attr create: %d\n",
+		       ret);
+		return ret;
+	}
+
 	hrtimer_init(&hr_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 	hrtimer_start(&hr_timer, KTIME_MAX, HRTIMER_MODE_REL);
 
@@ -103,6 +134,7 @@ static void __exit kernel_memory_exit(void)
 	if (class_alloc) {
 		class_remove_file(class_alloc, &class_attr_alloc_size);
 		class_remove_file(class_alloc, &class_attr_kmalloc);
+		class_remove_file(class_alloc, &class_attr_vmalloc);
 	}
 	class_destroy(class_alloc);
 

--- a/memory/log.txt
+++ b/memory/log.txt
@@ -1,31 +1,59 @@
+*-------------------------*kmalloc & vmalloc*--------------------------*
+
 Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
 
-3792                     kernel         787                 431                 
-                         virtual        9592                2922                
+1701                     kernel         533                 338                 
+                         virtual        7897                1644                
 
-9017                     kernel         2947                727                 
-                         virtual        9898                2340                
+15033                    kernel         4411                910                 
+                         virtual        8802                2246                
 
-19881                    kernel         8011                789                 
-                         virtual        12223               2238                
+17847                    kernel         5609                1000                
+                         virtual        8827                2085                
 
-31703                    kernel         5581                899                 
-                         virtual        15957               2970                
+28478                    kernel         5418                914                 
+                         virtual        13454               2819                
 
-37263                    kernel         11096               962                 
-                         virtual        15483               3061                
+36897                    kernel         11049               826                 
+                         virtual        14147               2418                
 
-49005                    kernel         8536                656                 
-                         virtual        13608               2460                
+45765                    kernel         11353               934                 
+                         virtual        50195               20093               
 
-52023                    kernel         8718                635                 
-                         virtual        12779               2384                
+49458                    kernel         8828                646                 
+                         virtual        12401               2672                
 
-61594                    kernel         8534                642                 
-                         virtual        19025               3386                
+58497                    kernel         12644               1198                
+                         virtual        209648              20867               
 
-70464                    kernel         20678               1291                
-                         virtual        18856               3376                
+66940                    kernel         18363               905                 
+                         virtual        16486               3068                
 
-81730                    kernel         16941               913                 
-                         virtual        22022               4159                
+78897                    kernel         17411               1334                
+                         virtual        27571               5090                
+
+
+
+*------------------------*get_free_pages*---------------------------*
+
+Order     Buffer size (bytes)      Allocation (ns)     Freeing (ns)        
+
+0         4096                     497                 303                 
+
+1         8192                     1121                385                 
+
+2         16384                    2594                601                 
+
+3         32768                    6106                817                 
+
+4         65536                    8699                629                 
+
+5         131072                   18928               893                 
+
+6         262144                   36869               1103                
+
+7         524288                   105431              2731                
+
+8         1048576                  158975              2296                
+
+9         2097152                  373053              5106                

--- a/memory/log.txt
+++ b/memory/log.txt
@@ -2,35 +2,35 @@
 
 Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
 
-12374                    kernel         4046                1025                
-                         virtual        9358                2593                
+11336                    kernel         5688                1308                
+                         virtual        9447                3327                
 
-24593                    kernel         6766                950                 
-                         virtual        9667                1998                
+32636                    kernel         6027                830                 
+                         virtual        11242               2606                
 
-48824                    kernel         11553               1173                
-                         virtual        17196               3251                
+34025                    kernel         11355               943                 
+                         virtual        9602                3571                
 
-53345                    kernel         7986                664                 
-                         virtual        13854               2396                
+56428                    kernel         8185                717                 
+                         virtual        11669               2366                
 
-81412                    kernel         15442               792                 
-                         virtual        17539               3015                
+71904                    kernel         16542               784                 
+                         virtual        14788               2843                
 
-83048                    kernel         15614               730                 
-                         virtual        14907               2895                
+90812                    kernel         16153               688                 
+                         virtual        15931               2907                
 
-108850                   kernel         23327               1383                
-                         virtual        32555               6344                
+99945                    kernel         16326               780                 
+                         virtual        16111               3181                
 
-116873                   kernel         19991               966                 
-                         virtual        32272               5707                
+124562                   kernel         16176               756                 
+                         virtual        22866               4543                
 
-134030                   kernel         38414               1003                
-                         virtual        29246               5403                
+137177                   kernel         38456               1153                
+                         virtual        30863               5513                
 
-160692                   kernel         36838               987                 
-                         virtual        254117              13233               
+161411                   kernel         37389               1248                
+                         virtual        31801               6124                
 
 
 
@@ -38,72 +38,92 @@ Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)
 
 Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
 
-                         kernel         386                 245                 
-4                        zram           9086                1499                
-                         virtual        6410                1542                
+                         kernel         457                 196                 
+4                        zram           7169                1149                
+                         virtual        5118                1342                
 
-                         kernel         533                 248                 
-8                        zram           3318                1486                
-                         virtual        9337                1978                
+                         kernel         449                 198                 
+8                        zram           2340                1192                
+                         virtual        4428                1410                
 
-                         kernel         475                 285                 
-16                       zram           2588                1353                
-                         virtual        5666                1405                
+                         kernel         335                 202                 
+16                       zram           2606                1267                
+                         virtual        4988                1491                
 
-                         kernel         307                 185                 
-32                       zram           4165                1586                
-                         virtual        4771                1802                
+                         kernel         236                 155                 
+32                       zram           3692                1530                
+                         virtual        4791                1477                
 
-                         kernel         279                 191                 
-64                       zram           2455                1177                
-                         virtual        5282                1570                
+                         kernel         320                 138                 
+64                       zram           2417                1122                
+                         virtual        4665                1417                
 
-                         kernel         206                 139                 
-128                      zram           3590                1500                
-                         virtual        5412                1534                
+                         kernel         159                 140                 
+128                      zram           3504                1537                
+                         virtual        4392                1327                
 
-                         kernel         455                 200                 
-256                      zram           2211                1295                
-                         virtual        8205                2606                
+                         kernel         319                 200                 
+256                      zram           2079                1098                
+                         virtual        4432                1516                
 
-                         kernel         263                 206                 
-512                      zram           4070                1694                
-                         virtual        4781                1552                
+                         kernel         244                 157                 
+512                      zram           3911                1782                
+                         virtual        4985                1393                
 
-                         kernel         235                 191                 
-1024                     zram           3771                1638                
-                         virtual        5566                1393                
+                         kernel         312                 277                 
+1024                     zram           4122                1776                
+                         virtual        5010                1624                
 
-                         kernel         371                 241                 
-2048                     zram           6173                1686                
-                         virtual        5623                1814                
+                         kernel         409                 276                 
+2048                     zram           3651                1593                
+                         virtual        5365                1495                
 
-                         kernel         449                 224                 
-4096                     zram           2324                1255                
-                         virtual        5671                1917                
+                         kernel         423                 225                 
+4096                     zram           2328                1114                
+                         virtual        4707                1271                
 
 
 
-*------------------------*get_free_pages*---------------------------*
+*----------------------*kmalloc & get_free_pages & vmalloc*----------------------*
 
-Order     Buffer size (bytes)      Allocation (ns)     Freeing (ns)        
+Order     Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
 
-0         4096                     929                 451                 
+                                   kernel         437                 227                 
+0         4096                     pages          613                 387                 
+                                   virtual        4510                1621                
 
-1         8192                     1311                383                 
+                                   kernel         1001                270                 
+1         8192                     pages          1283                377                 
+                                   virtual        5176                1690                
 
-2         16384                    2133                457                 
+                                   kernel         2788                750                 
+2         16384                    pages          2414                728                 
+                                   virtual        6002                1674                
 
-3         32768                    4018                561                 
+                                   kernel         4655                708                 
+3         32768                    pages          4322                479                 
+                                   virtual        8299                2228                
 
-4         65536                    9013                389                 
+                                   kernel         8698                648                 
+4         65536                    pages          7970                507                 
+                                   virtual        12631               2983                
 
-5         131072                   17499               709                 
+                                   kernel         16571               713                 
+5         131072                   pages          15109               620                 
+                                   virtual        23763               4533                
 
-6         262144                   31974               1042                
+                                   kernel         57773               1105                
+6         262144                   pages          40179               1020                
+                                   virtual        38812               7383                
 
-7         524288                   97945               2504                
+                                   kernel         63579               1223                
+7         524288                   pages          61553               1225                
+                                   virtual        75492               13528               
 
-8         1048576                  209419              3669                
+                                   kernel         122523              1530                
+8         1048576                  pages          119807              1878                
+                                   virtual        153615              28411               
 
-9         2097152                  318210              4180                
+                                   kernel         246018              2249                
+9         2097152                  pages          239435              3035                
+                                   virtual        367090              64309               

--- a/memory/log.txt
+++ b/memory/log.txt
@@ -1,11 +1,8 @@
 clang-format-9 -i kernel_memory.c
 make -C /lib/modules/5.3.0-26-generic/build M=/home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory modules
 make[1]: Entering directory '/usr/src/linux-headers-5.3.0-26-generic'
-  CC [M]  /home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory/kernel_memory.o
   Building modules, stage 2.
   MODPOST 1 modules
-  CC      /home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory/kernel_memory.mod.o
-  LD [M]  /home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory/kernel_memory.ko
 make[1]: Leaving directory '/usr/src/linux-headers-5.3.0-26-generic'
 sudo insmod kernel_memory.ko
 lsmod | head -n 3
@@ -15,16 +12,17 @@ rfcomm                 81920  4
 
 *--------------------------*kmalloc()*--------------------------*
 Buffer size (bytes)      Allocation (ns)     Freeing (ns)        
-1024                     290                 274                 
-1024                     283                 166                 
-1024                     388                 211                 
-1024                     313                 208                 
-1024                     340                 193                 
-1024                     379                 228                 
-1024                     543                 386                 
-1024                     446                 311                 
-1024                     413                 255                 
-1024                     432                 292                 
+20                       293                 150                 
+1236                     369                 174                 
+2333                     537                 240                 
+3304                     561                 281                 
+4797                     1213                196                 
+5166                     1119                220                 
+6484                     1648                293                 
+7529                     1248                271                 
+8360                     3288                729                 
+9578                     2913                653                 
+
 sudo rmmod kernel_memory.ko
 lsmod | head -n 3
 Module                  Size  Used by

--- a/memory/log.txt
+++ b/memory/log.txt
@@ -1,0 +1,32 @@
+clang-format-9 -i kernel_memory.c
+make -C /lib/modules/5.3.0-26-generic/build M=/home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory modules
+make[1]: Entering directory '/usr/src/linux-headers-5.3.0-26-generic'
+  CC [M]  /home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory/kernel_memory.o
+  Building modules, stage 2.
+  MODPOST 1 modules
+  CC      /home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory/kernel_memory.mod.o
+  LD [M]  /home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory/kernel_memory.ko
+make[1]: Leaving directory '/usr/src/linux-headers-5.3.0-26-generic'
+sudo insmod kernel_memory.ko
+lsmod | head -n 3
+Module                  Size  Used by
+kernel_memory          16384  0
+rfcomm                 81920  4
+
+*--------------------------*kmalloc()*--------------------------*
+Buffer size (bytes)      Allocation (ns)     Freeing (ns)        
+1024                     290                 274                 
+1024                     283                 166                 
+1024                     388                 211                 
+1024                     313                 208                 
+1024                     340                 193                 
+1024                     379                 228                 
+1024                     543                 386                 
+1024                     446                 311                 
+1024                     413                 255                 
+1024                     432                 292                 
+sudo rmmod kernel_memory.ko
+lsmod | head -n 3
+Module                  Size  Used by
+rfcomm                 81920  4
+ccm                    20480  3

--- a/memory/log.txt
+++ b/memory/log.txt
@@ -1,30 +1,31 @@
-clang-format-9 -i kernel_memory.c
-make -C /lib/modules/5.3.0-26-generic/build M=/home/matthewzorin/Linux_Kernel/gl-kernel-basecamp-2020/memory modules
-make[1]: Entering directory '/usr/src/linux-headers-5.3.0-26-generic'
-  Building modules, stage 2.
-  MODPOST 1 modules
-make[1]: Leaving directory '/usr/src/linux-headers-5.3.0-26-generic'
-sudo insmod kernel_memory.ko
-lsmod | head -n 3
-Module                  Size  Used by
-kernel_memory          16384  0
-rfcomm                 81920  4
+Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
 
-*--------------------------*kmalloc()*--------------------------*
-Buffer size (bytes)      Allocation (ns)     Freeing (ns)        
-20                       293                 150                 
-1236                     369                 174                 
-2333                     537                 240                 
-3304                     561                 281                 
-4797                     1213                196                 
-5166                     1119                220                 
-6484                     1648                293                 
-7529                     1248                271                 
-8360                     3288                729                 
-9578                     2913                653                 
+3792                     kernel         787                 431                 
+                         virtual        9592                2922                
 
-sudo rmmod kernel_memory.ko
-lsmod | head -n 3
-Module                  Size  Used by
-rfcomm                 81920  4
-ccm                    20480  3
+9017                     kernel         2947                727                 
+                         virtual        9898                2340                
+
+19881                    kernel         8011                789                 
+                         virtual        12223               2238                
+
+31703                    kernel         5581                899                 
+                         virtual        15957               2970                
+
+37263                    kernel         11096               962                 
+                         virtual        15483               3061                
+
+49005                    kernel         8536                656                 
+                         virtual        13608               2460                
+
+52023                    kernel         8718                635                 
+                         virtual        12779               2384                
+
+61594                    kernel         8534                642                 
+                         virtual        19025               3386                
+
+70464                    kernel         20678               1291                
+                         virtual        18856               3376                
+
+81730                    kernel         16941               913                 
+                         virtual        22022               4159                

--- a/memory/log.txt
+++ b/memory/log.txt
@@ -1,36 +1,86 @@
-*-------------------------*kmalloc & vmalloc*--------------------------*
+*--------------------*kmalloc & vmalloc (random buffer)*---------------------*
 
 Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
 
-1701                     kernel         533                 338                 
-                         virtual        7897                1644                
+12374                    kernel         4046                1025                
+                         virtual        9358                2593                
 
-15033                    kernel         4411                910                 
-                         virtual        8802                2246                
+24593                    kernel         6766                950                 
+                         virtual        9667                1998                
 
-17847                    kernel         5609                1000                
-                         virtual        8827                2085                
+48824                    kernel         11553               1173                
+                         virtual        17196               3251                
 
-28478                    kernel         5418                914                 
-                         virtual        13454               2819                
+53345                    kernel         7986                664                 
+                         virtual        13854               2396                
 
-36897                    kernel         11049               826                 
-                         virtual        14147               2418                
+81412                    kernel         15442               792                 
+                         virtual        17539               3015                
 
-45765                    kernel         11353               934                 
-                         virtual        50195               20093               
+83048                    kernel         15614               730                 
+                         virtual        14907               2895                
 
-49458                    kernel         8828                646                 
-                         virtual        12401               2672                
+108850                   kernel         23327               1383                
+                         virtual        32555               6344                
 
-58497                    kernel         12644               1198                
-                         virtual        209648              20867               
+116873                   kernel         19991               966                 
+                         virtual        32272               5707                
 
-66940                    kernel         18363               905                 
-                         virtual        16486               3068                
+134030                   kernel         38414               1003                
+                         virtual        29246               5403                
 
-78897                    kernel         17411               1334                
-                         virtual        27571               5090                
+160692                   kernel         36838               987                 
+                         virtual        254117              13233               
+
+
+
+*------------------------*kmalloc & zsmalloc & vmalloc*------------------------*
+
+Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)        
+
+                         kernel         386                 245                 
+4                        zram           9086                1499                
+                         virtual        6410                1542                
+
+                         kernel         533                 248                 
+8                        zram           3318                1486                
+                         virtual        9337                1978                
+
+                         kernel         475                 285                 
+16                       zram           2588                1353                
+                         virtual        5666                1405                
+
+                         kernel         307                 185                 
+32                       zram           4165                1586                
+                         virtual        4771                1802                
+
+                         kernel         279                 191                 
+64                       zram           2455                1177                
+                         virtual        5282                1570                
+
+                         kernel         206                 139                 
+128                      zram           3590                1500                
+                         virtual        5412                1534                
+
+                         kernel         455                 200                 
+256                      zram           2211                1295                
+                         virtual        8205                2606                
+
+                         kernel         263                 206                 
+512                      zram           4070                1694                
+                         virtual        4781                1552                
+
+                         kernel         235                 191                 
+1024                     zram           3771                1638                
+                         virtual        5566                1393                
+
+                         kernel         371                 241                 
+2048                     zram           6173                1686                
+                         virtual        5623                1814                
+
+                         kernel         449                 224                 
+4096                     zram           2324                1255                
+                         virtual        5671                1917                
 
 
 
@@ -38,22 +88,22 @@ Buffer size (bytes)      Memory         Allocation (ns)     Freeing (ns)
 
 Order     Buffer size (bytes)      Allocation (ns)     Freeing (ns)        
 
-0         4096                     497                 303                 
+0         4096                     929                 451                 
 
-1         8192                     1121                385                 
+1         8192                     1311                383                 
 
-2         16384                    2594                601                 
+2         16384                    2133                457                 
 
-3         32768                    6106                817                 
+3         32768                    4018                561                 
 
-4         65536                    8699                629                 
+4         65536                    9013                389                 
 
-5         131072                   18928               893                 
+5         131072                   17499               709                 
 
-6         262144                   36869               1103                
+6         262144                   31974               1042                
 
-7         524288                   105431              2731                
+7         524288                   97945               2504                
 
-8         1048576                  158975              2296                
+8         1048576                  209419              3669                
 
-9         2097152                  373053              5106                
+9         2097152                  318210              4180                

--- a/memory/memory_test.sh
+++ b/memory/memory_test.sh
@@ -1,0 +1,13 @@
+ #!/bin/bash
+
+make format
+make
+make install
+printf "\n*--------------------------*kmalloc()*--------------------------*\n"
+printf "%-25s%-20s%-20s\n" "Buffer size (bytes)" "Allocation (ns)" "Freeing (ns)"
+for (( i = 0; i < 10; ++i)); do
+        printf "%-25lu%-40s\n" 1024 "$(cat /sys/class/alloc-test/kmalloc)"
+done
+make uninstall
+
+exit $RETURN_SUCCESS

--- a/memory/memory_test.sh
+++ b/memory/memory_test.sh
@@ -11,24 +11,27 @@ function get_rand {
 
 RANDOM=$SECONDS
 sys_dir=/sys/class/alloc_test
-start_upper=1024
+start_upper=8192
 curr_upper=$start_upper
 curr_lower=0
 
 make format
 make
 make install
-printf "\n*--------------------------*kmalloc()*--------------------------*\n"
-printf "%-25s%-20s%-20s\n" "Buffer size (bytes)" "Allocation (ns)" "Freeing (ns)"
+echo "" > log.txt #Cleaning log file
+exec 3>log.txt 4>&1 1>&3 #Open to write new file descriptor, save stdout, stdout > log.txt
+printf "%-25s%-15s%-20s%-20s\n" "Buffer size (bytes)" "Memory" "Allocation (ns)" "Freeing (ns)"
 for (( i = 0; i < 10; ++i)); do
         rand_size=$(get_rand ${curr_upper} ${curr_lower})
         curr_lower=$curr_upper
         let "curr_upper += start_upper"
         echo $rand_size > ${sys_dir}/alloc_size
         kmalloc=( $(cat ${sys_dir}/kmalloc) )
-        printf "%-25lu%-20s%-20s\n" "$(cat ${sys_dir}/alloc_size)" ${kmalloc[0]} ${kmalloc[1]}
+        vmalloc=( $(cat ${sys_dir}/vmalloc) )
+        printf "\n%-25lu%-15s%-20s%-20s\n" "$(cat ${sys_dir}/alloc_size)" "kernel" ${kmalloc[0]} ${kmalloc[1]}
+        printf "%-25s%-15s%-20s%-20s\n" "" "virtual" ${vmalloc[0]} ${vmalloc[1]}
 done
-echo ""
+exec 1>&4 3>&- 4>&- #Return stdout, close log.txt, close temporary stdout
 make uninstall
 
 exit $RETURN_SUCCESS

--- a/memory/memory_test.sh
+++ b/memory/memory_test.sh
@@ -50,12 +50,17 @@ for (( i = 4; i <= $page_size; i *= 2)); do
         printf "%-25s%-15s%-20s%-20s\n" "" "virtual" ${vmalloc[0]} ${vmalloc[1]}
 done
 
-echo -e "\n\n\n*------------------------*get_free_pages*---------------------------*"
-printf "\n%-10s%-25s%-20s%-20s\n" "Order" "Buffer size (bytes)" "Allocation (ns)" "Freeing (ns)"
+echo -e "\n\n\n*----------------------*kmalloc & get_free_pages & vmalloc*----------------------*"
+printf "\n%-10s%-25s%-15s%-20s%-20s\n" "Order" "Buffer size (bytes)" "Memory" "Allocation (ns)" "Freeing (ns)"
 for (( i = 0; i < 10; ++i)); do
         echo $i > ${sys_dir}/page_order
+        echo $page_size > ${sys_dir}/alloc_size
+        kmalloc=( $(cat ${sys_dir}/kmalloc) )
         pages=( $(cat ${sys_dir}/pages) )
-        printf "\n%-10u%-25s%-20s%-20s\n" "$(cat ${sys_dir}/page_order)" $page_size ${pages[0]} ${pages[1]}
+        vmalloc=( $(cat ${sys_dir}/vmalloc) )
+        printf "\n%-35s%-15s%-20s%-20s\n" "" "kernel" ${kmalloc[0]} ${kmalloc[1]}
+        printf "%-10s%-25s%-15s%-20s%-20s\n" "$(cat ${sys_dir}/page_order)" "$(cat ${sys_dir}/alloc_size)" "pages" ${pages[0]} ${pages[1]}
+        printf "%-35s%-15s%-20s%-20s\n" "" "virtual" ${vmalloc[0]} ${vmalloc[1]}
         let "page_size *= 2"
 done
 

--- a/memory/memory_test.sh
+++ b/memory/memory_test.sh
@@ -68,4 +68,3 @@ exec 1>&4 3>&- 4>&- #Return stdout, close log.txt, close temporary stdout
 echo "End of output redirection"
 make uninstall
 
-exit $RETURN_SUCCESS

--- a/memory/memory_test.sh
+++ b/memory/memory_test.sh
@@ -1,13 +1,34 @@
  #!/bin/bash
 
+#For getting a random number in a range from $1 to $2
+function get_rand {
+        local temp=$RANDOM
+        local upper_bound=$1
+        local lower_bound=$2
+        let "temp = temp % (upper_bound - lower_bound) + lower_bound"
+        echo $temp
+}
+
+RANDOM=$SECONDS
+sys_dir=/sys/class/alloc_test
+start_upper=1024
+curr_upper=$start_upper
+curr_lower=0
+
 make format
 make
 make install
 printf "\n*--------------------------*kmalloc()*--------------------------*\n"
 printf "%-25s%-20s%-20s\n" "Buffer size (bytes)" "Allocation (ns)" "Freeing (ns)"
 for (( i = 0; i < 10; ++i)); do
-        printf "%-25lu%-40s\n" 1024 "$(cat /sys/class/alloc-test/kmalloc)"
+        rand_size=$(get_rand ${curr_upper} ${curr_lower})
+        curr_lower=$curr_upper
+        let "curr_upper += start_upper"
+        echo $rand_size > ${sys_dir}/alloc_size
+        kmalloc=( $(cat ${sys_dir}/kmalloc) )
+        printf "%-25lu%-20s%-20s\n" "$(cat ${sys_dir}/alloc_size)" ${kmalloc[0]} ${kmalloc[1]}
 done
+echo ""
 make uninstall
 
 exit $RETURN_SUCCESS

--- a/timer/README.md
+++ b/timer/README.md
@@ -1,0 +1,19 @@
+# Internal Kernel API (Time Management)
+
+## Homework
+
+1. User space. Implement program which shows absolute time in user space.
+Pull request should contain the commit with source code and
+generated output in text format.
+
+2. Kernel space.
+  a) Implement kernel module with API in sysfs,
+     which show relation time in maximum possible resolution 
+     passed since previous read of it.
+  b) Implement kernel module with API in sysfs which shows absolute time of
+     previous reading with maximum resolution like ‘400.123567’ seconds.
+  c) (optional) Implement kernel module with API in sysfs which shows
+     average processor load updated once in a second.
+Pull request should contain the commit with source code and
+text output from sysfs.
+ 


### PR DESCRIPTION
Create the kernel module with sysfs interfaces:
    - kmalloc, zsmalloc, vmalloc and pages. Read these attributes to allocate and free buffer, get a result in format: " 'allocation time' 'freeing time' "
    - alloc_size to control buffer size of functions kmalloc, zsmalloc and vmalloc
    - page_order to define the order of allocated pages.
Make the test script, which display commprassion tables:
    - kmalloc, vmalloc of random buffer (limited to variable)
    - kmalloc, zsmalloc, vmalloc of short buffer (to zsmalloc limit)
    - kmalloc, get_free_pages, vmalloc of larger buffer (from the previous limit to 2^21 bytes).
Redirect script output to log.txt