### PR TITLE
Homework3 : time(kernel)

### DIFF
--- a/time/Makefile
+++ b/time/Makefile
@@ -1,0 +1,7 @@
+
+obj-m+=timeModule.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean 

--- a/time/timeModule.c
+++ b/time/timeModule.c
@@ -2,21 +2,76 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 
+#include <linux/fs.h>
+#include <linux/device.h>
+#include <linux/cdev.h>
+#include <linux/pci.h>
+#include <linux/version.h>
+#include <linux/init.h>
+
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Nick");
 MODULE_DESCRIPTION("Timer");
 MODULE_VERSION("0.01");
 
+static ssize_t read_sysfs(struct class *class, struct class_attribute *attr,
+			  char *buf);
+static ssize_t write_sysfs(struct class *class, struct class_attribute *attr,
+			   const char *buf, size_t count);
+
+/* sysfs 
+ */
+static struct class *timer;
+static struct class_attribute myTim =
+	__ATTR(myTim, S_IWUSR | S_IRUGO, read_sysfs, write_sysfs);
+
+
+static ssize_t read_sysfs(struct class *class, struct class_attribute *attr,
+			  char *buf)
+{
+	return strlen(buf);
+}
+
+
+static ssize_t write_sysfs(struct class *class, struct class_attribute *attr,
+			   const char *buf, size_t count)
+{
+	return count;
+}
+
+static int init_sysfs(void)
+{
+	timer = class_create(THIS_MODULE, "Tim");
+
+	// need to detect bad clacc create
+
+	class_create_file(timer, &myTim);
+
+	return 0;
+}
+
+static int exit_sysfs(void)
+{
+	class_remove_file(timer, &myTim);
+
+	// need to detect bad remove and destroy
+
+	class_destroy(timer);
+
+	return 0;
+}
+
 
 static int __init mod_init(void)
 {
+    init_sysfs();
 	return 0;
 }
 
 static void __exit mod_exit(void)
 {
-
+    exit_sysfs();
 }
 
 module_init(mod_init);
-module_exit(mod_exit);  
+module_exit(mod_exit);

--- a/time/timeModule.c
+++ b/time/timeModule.c
@@ -34,14 +34,23 @@ struct st {
 	unsigned long long nsec;
 } myTimer;
 
+static enum hrtimer_restart timCallback(struct hrtimer *tim)
+{
+	myTimer.nsec++;
+	hrtimer_forward(tim, tim->base->get_time(), myTimer.period);
+	return HRTIMER_RESTART;
+}
+
+
 static int initTim(void)
 {
 	myTimer.mode = 0x1;
 	myTimer.period = ktime_set(0, 1000);
 	hrtimer_init(&myTimer.hrtim, CLOCK_REALTIME, myTimer.mode);
-	myTimer.hrtim.function = NULL;
+	myTimer.hrtim.function = timCallback;
 	return 0;
 }
+
 
 static ssize_t read_sysfs(struct class *class, struct class_attribute *attr,
 			  char *buf)

--- a/time/timeModule.c
+++ b/time/timeModule.c
@@ -1,0 +1,22 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Nick");
+MODULE_DESCRIPTION("Timer");
+MODULE_VERSION("0.01");
+
+
+static int __init mod_init(void)
+{
+	return 0;
+}
+
+static void __exit mod_exit(void)
+{
+
+}
+
+module_init(mod_init);
+module_exit(mod_exit);  


### PR DESCRIPTION
### Desription
Kernel module with sysfs interface. It shows relation time in maximum possible resolution passed since previous read of it. And shows absolute time of previous reading.

Module's mode can be changed by writing 0 - show relation time, and everything else - show absolute time.

### Example
```
cd /sys/class/Tim/
cat myTim 
2.74955
echo "1" > myTim
cat myTim
38.36385
cat myTim; sleep 10 && cat myTim
196.77832
207.63388
```

Here is some problem, hrtimer callback return too early after forwarding it. 