### PR TITLE
A solution for the sixth hw (irq)

### DIFF
--- a/tsl2580/Makefile
+++ b/tsl2580/Makefile
@@ -1,0 +1,9 @@
+obj-m += tsl2580.o
+KERN_DIR ?= /lib/modules/$(shell uname -r)/build
+
+all:
+	$(MAKE) -C $(KERN_DIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERN_DIR) M=$(PWD) clean
+

--- a/tsl2580/tsl2580.c
+++ b/tsl2580/tsl2580.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 #include <linux/module.h>
 #include <linux/device.h>
 #include <linux/i2c.h>
@@ -15,8 +16,11 @@ struct tsl2580_dev {
 static struct tsl2580_dev mydev;
 static struct class *tsl2580_class;
 
-static ssize_t who_am_i_show(struct class *class, struct class_attribute *attr, char *buf);
-static int tsl2580_probe(struct i2c_client *client, const struct i2c_device_id *id);
+static ssize_t who_am_i_show(struct class *class,
+			struct class_attribute *attr,
+			char *buf);
+static int tsl2580_probe(struct i2c_client *client,
+			const struct i2c_device_id *id);
 static int tsl2580_remove(struct i2c_client *client);
 
 static const struct i2c_device_id tsl2580_i2c_id[] = {
@@ -51,21 +55,25 @@ static int __must_check tsl2580_default_config(struct tsl2580_dev *dev)
 
 	if (!dev->client)
 		return -EINVAL;
-	ret = i2c_smbus_write_byte(dev->client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_CTRL_REG);
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG| TSL2580_TRNS_BLOCK | TSL2580_CTRL_REG);
 	if (ret < 0)
 		return ret;
 	/* Enable TSL2580 */
-	ret = i2c_smbus_write_byte(dev->client, TSL2580_CTRL_POWER | TSL2580_CTRL_ADC_EN);
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CTRL_POWER | TSL2580_CTRL_ADC_EN);
 	if (ret < 0)
 		return ret;
-	ret = i2c_smbus_write_byte(dev->client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_TIMING_REG);
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_TIMING_REG);
 	if (ret < 0)
 		return ret;
 	/* 148 integration cycles by default */
 	ret = i2c_smbus_write_byte(dev->client, TSL2580_TIMING_148);
 	if (ret < 0)
 		return ret;
-	ret = i2c_smbus_write_byte(dev->client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ANALOG_REG);
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ANALOG_REG);
 	if (ret < 0)
 		return ret;
 	/* 16x analog gain by default */
@@ -85,9 +93,10 @@ static int tsl2580_probe(struct i2c_client *client,
 	pr_info("tsl2580: i2c client address is 0x%X\n", client->addr);
 
 	mydev.client = client;
-	ret = i2c_smbus_write_byte(mydev.client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ID_REG);
+	ret = i2c_smbus_write_byte(mydev.client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ID_REG);
 	if (ret < 0) {
-		pr_err("tsl2580: error %d occured writing to the device\n", ret);
+		pr_err("tsl2580: error %d writing to the device\n", ret);
 		return ret;
 	}
 	id = i2c_smbus_read_byte(mydev.client);
@@ -111,15 +120,18 @@ static int tsl2580_remove(struct i2c_client *client)
 }
 
 
-static ssize_t who_am_i_show(struct class *class, struct class_attribute *attr, char *buf)
+static ssize_t who_am_i_show(struct class *class,
+			struct class_attribute *attr,
+			char *buf)
 {
 	char *type;
 	u8 id;
 	s32 ret;
 
-	ret = i2c_smbus_write_byte(mydev.client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ID_REG);
+	ret = i2c_smbus_write_byte(mydev.client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ID_REG);
 	if (ret < 0) {
-		pr_err("tsl2580: error %d occured writing to the device\n", ret);
+		pr_err("tsl2580: error %d writing to the device\n", ret);
 		return ret;
 	}
 	
@@ -142,7 +154,7 @@ static int __init tsl2580_init(void)
 
 	ret = i2c_add_driver(&tsl2580_i2c_driver);
 	if (ret < 0) {
-		pr_err("tsl2580: failed to add an i2c driver; error %d\n", ret);
+		pr_err("tsl2580: error %d adding an i2c driver\n", ret);
 		return ret;
 	}
 	pr_info("tsl2580: i2c driver created\n");
@@ -150,13 +162,14 @@ static int __init tsl2580_init(void)
 	tsl2580_class = class_create(THIS_MODULE, TSL2580_CLASS_NAME);
 	if (IS_ERR(tsl2580_class)) {
 		ret = PTR_ERR(tsl2580_class);
-		pr_err("tsl2580: failed to create a class; error %ld\n", PTR_ERR(tsl2580_class));
+		pr_err("tsl2580: failed to create a class; error %ld\n",
+		PTR_ERR(tsl2580_class));
 		goto err;
 	}
 	
 	ret = class_create_file(tsl2580_class, &class_attr_who_am_i);
 	if (ret < 0) {
-		pr_err("tsl2580: failed to create a who_am_i class attribute; error %d\n", ret);
+		pr_err("tsl2580: error %d creating a who_am_i attribute\n", ret);
 		goto err;
 	}
 

--- a/tsl2580/tsl2580.c
+++ b/tsl2580/tsl2580.c
@@ -9,6 +9,32 @@
 
 #define TSL2580_CLASS_NAME "tsl2580"
 
+/* Scale factors for lux approximation */
+#define LUX_SCALE 16
+#define RATIO_SCALE 9
+#define ADC_SCALE 16
+
+/* 128x gain scaling factors */
+#define ADC0_SCALE_111X 107
+#define ADC1_SCALE_111X 115
+
+/* Not sure if the preprocessor performs floating point evaluation */
+#define ODFN_K1C 0x009A /* 0.30 * 2 ^ RATIO_SCALE */
+#define ODFN_B1C 0x2148 /* 0.130 * 2 ^ LUX_SCALE */
+#define ODFN_M1C 0x3D71 /* 0.240 * 2 ^ LUX_SCALE */
+#define ODFN_K2C 0x00C3 /* 0.38 * 2 ^ RATIO_SCALE */
+#define ODFN_B2C 0x2A37 /* 0.1649 * 2 ^ LUX_SCALE */
+#define ODFN_M2C 0x5B30 /* 0.3562 * 2 ^ LUX_SCALE */
+#define ODFN_K3C 0x00E6 /* 0.45 * 2 ^ RATIO_SCALE */
+#define ODFN_B3C 0x18EF /* 0.0974 * 2 ^ LUX_SCALE */
+#define ODFN_M3C 0x2DB9 /* 0.1786 * 2 ^ LUX_SCALE */
+#define ODFN_K4C 0x0114 /* 0.54 * 2 ^ RATIO_SCALE */
+#define ODFN_B4C 0x0FDF /* 0.062 * 2 ^ LUX_SCALE */
+#define ODFN_M4C 0x199A /* 0.10 * 2 ^ LUX_SCALE */
+#define ODFN_K5C 0x0114 /* 0.54 * 2 ^ RATIO_SCALE */
+#define ODFN_B5C 0x0000 /* 0.00 * 2 ^ LUX_SCALE */
+#define ODFN_M5C 0x0000 /* 0.00 * 2 ^ LUX_SCALE */
+
 struct tsl2580_dev {
 	struct i2c_client *client;
 };
@@ -18,6 +44,7 @@ static struct class *tsl2580_class;
 
 static s32 tsl2580_read_adc0(struct tsl2580_dev *dev);
 static s32 tsl2580_read_adc1(struct tsl2580_dev *dev);
+static s32 tsl2580_read_lux(struct tsl2580_dev *dev);
 static ssize_t who_am_i_show(struct class *class,
 			struct class_attribute *attr,
 			char *buf);
@@ -25,6 +52,9 @@ static ssize_t adc0_show(struct class *class,
 			struct class_attribute *attr,
 			char *buf);
 static ssize_t adc1_show(struct class *class,
+			struct class_attribute *attr,
+			char *buf);
+static ssize_t lux_show(struct class *class,
 			struct class_attribute *attr,
 			char *buf);
 static int tsl2580_probe(struct i2c_client *client,
@@ -60,6 +90,86 @@ static struct class_attribute class_attr_adc0 =
 				__ATTR(adc0, 00644, adc0_show, NULL);
 static struct class_attribute class_attr_adc1 =
 				__ATTR(adc1, 00644, adc1_show, NULL);
+static struct class_attribute class_attr_lux =
+				__ATTR(lux, 00644, lux_show, NULL);
+
+static s32 tsl2580_read_lux(struct tsl2580_dev *dev)
+{
+	s32 low, high;
+	u8 gain, ic;
+	u32 sc0, sc1, ratio;
+
+	low = high = gain = ic = sc0 = sc1 = ratio = 0;
+
+	low = tsl2580_read_adc0(dev);
+	if (low < 0)
+		return low;
+	high = tsl2580_read_adc1(dev);
+	if (high < 0)
+		return high;
+	gain = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ANALOG_REG);
+	if (gain < 0)
+		return gain;
+	gain = i2c_smbus_read_byte(dev->client);
+	if (gain < 0)
+		return gain;
+	ic = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_TIMING_REG);
+	if (ic < 0)
+		return ic;
+	ic = i2c_smbus_read_byte(dev->client);
+
+	/* Have no idea why it's like this.
+	 * Datasheet suggests particularly this formula.
+	 */
+	if (ic == TSL2580_TIMING_148)
+		sc0 = (1 << ADC_SCALE);
+	else
+		sc0 = (TSL2580_TIMING_148 << ADC_SCALE) / ic;
+	
+	switch(gain) {
+	case TSL2580_ANALOG_GAIN_1X:
+		sc1 = sc0;
+		break;
+	case TSL2580_ANALOG_GAIN_8X:
+		sc0 = sc0 >> 3;
+		sc1 = sc0;
+		break;
+	case TSL2580_ANALOG_GAIN_16X:
+		sc0 = sc0 >> 4;
+		sc1 = sc0;
+	case TSL2580_ANALOG_GAIN_111X:
+		sc1 = sc0 / ADC1_SCALE_111X;
+		sc0 = sc0 / ADC0_SCALE_111X;
+		break;
+	}
+	low = (sc0 * low) >> ADC_SCALE;
+	high = (sc1 * high) >> ADC_SCALE;
+	if (low)
+		ratio = (high << (RATIO_SCALE + 1)) / low;
+	ratio = (ratio + 1) >> 1;
+	if (ratio <= ODFN_K1C) {
+		sc0 = ODFN_B1C;
+		sc1 = ODFN_M1C;
+	} else if (ratio <= ODFN_K2C) {
+		sc0 = ODFN_B2C;
+		sc1 = ODFN_M2C;
+	} else if (ratio <= ODFN_K3C) {
+		sc0 = ODFN_B3C;
+		sc1 = ODFN_M3C;
+	} else if (ratio <= ODFN_K4C) {
+		sc0 = ODFN_B4C;
+		sc1 = ODFN_M4C;
+	} else {
+		sc0 = ODFN_B5C;
+		sc1 = ODFN_M5C;
+	}
+	low = (low * sc0) - (high * sc1);
+	low += (1 << (LUX_SCALE - 1));
+	
+	return low >> LUX_SCALE;
+}
 
 static s32 tsl2580_read_adc1(struct tsl2580_dev *dev)
 {
@@ -75,7 +185,7 @@ static s32 tsl2580_read_adc1(struct tsl2580_dev *dev)
 	high = i2c_smbus_write_byte(dev->client,
 	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_DATA1HIGH_REG);
 	if (high < 0)
-		return low;
+		return high;
 	high = i2c_smbus_read_byte(dev->client);
 	if (high < 0)
 		return high;
@@ -98,7 +208,7 @@ static s32 tsl2580_read_adc0(struct tsl2580_dev *dev)
 	high = i2c_smbus_write_byte(dev->client,
 	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_DATA0HIGH_REG);
 	if (high < 0)
-		return low;
+		return high;
 	high = i2c_smbus_read_byte(dev->client);
 	if (high < 0)
 		return high;
@@ -235,7 +345,21 @@ static ssize_t adc1_show(struct class *class,
 	return res;
 }
 
+static ssize_t lux_show(struct class *class,
+			struct class_attribute *attr,
+			char *buf)
+{
+	s32 res;
 
+	res = tsl2580_read_lux(&mydev);
+	if (res < 0) {
+		pr_err("tsl2580: error %d reading lux\n", res);
+		return res;
+	}
+	res = sprintf(buf, "%d\n", res);
+	
+	return res;
+}
 
 static int __init tsl2580_init(void)
 {
@@ -251,11 +375,9 @@ static int __init tsl2580_init(void)
 	tsl2580_class = class_create(THIS_MODULE, TSL2580_CLASS_NAME);
 	if (IS_ERR(tsl2580_class)) {
 		ret = PTR_ERR(tsl2580_class);
-		pr_err("tsl2580: failed to create a class; error %ld\n",
-		PTR_ERR(tsl2580_class));
+		pr_err("tsl2580: failed to create a class; error %ld\n", ret);
 		goto err;
 	}
-	
 	ret = class_create_file(tsl2580_class, &class_attr_who_am_i);
 	if (ret < 0) {
 		pr_err("tsl2580: error %d creating a who_am_i attribute\n", ret);
@@ -269,6 +391,12 @@ static int __init tsl2580_init(void)
 	ret = class_create_file(tsl2580_class, &class_attr_adc1);
 	if (ret < 0) {
 		pr_err("tsl2580: error %d creating an adc1 attribute\n", ret);
+		goto err;
+	}
+	ret = class_create_file(tsl2580_class, &class_attr_lux);
+	if (ret < 0) {
+		pr_err("tsl2580: error %d creating a lux attribute\n", ret);
+		goto err;
 	}
 
 	pr_info("tsl2580: init succeded\n");
@@ -278,6 +406,7 @@ err:
 	class_remove_file(tsl2580_class, &class_attr_who_am_i);
 	class_remove_file(tsl2580_class, &class_attr_adc0);
 	class_remove_file(tsl2580_class, &class_attr_adc1);
+	class_remove_file(tsl2580_class, &class_attr_lux);
 	class_destroy(tsl2580_class);
 	return ret;
 }
@@ -288,6 +417,7 @@ static void __exit tsl2580_exit(void)
 	class_remove_file(tsl2580_class, &class_attr_who_am_i);
 	class_remove_file(tsl2580_class, &class_attr_adc0);
 	class_remove_file(tsl2580_class, &class_attr_adc1);
+	class_remove_file(tsl2580_class, &class_attr_lux);
 	class_destroy(tsl2580_class);
 	i2c_del_driver(&tsl2580_i2c_driver);
 	pr_info("tsl2580: exit\n");

--- a/tsl2580/tsl2580.c
+++ b/tsl2580/tsl2580.c
@@ -37,6 +37,9 @@
 
 struct tsl2580_dev {
 	struct i2c_client *client;
+	u16 data_adc0;
+	u16 data_adc1;
+	u16 data_lux;
 };
 
 static struct tsl2580_dev mydev;
@@ -326,6 +329,7 @@ static ssize_t adc0_show(struct class *class,
 		pr_err("tsl2580: error %d reading adc0\n", res);
 		return res;
 	}
+	mydev.data_adc0 = (u16)res;
 	res = sprintf(buf, "%d\n", res);
 	return res;
 }
@@ -341,6 +345,7 @@ static ssize_t adc1_show(struct class *class,
 		pr_err("tsl2580: error %d reading adc0\n", res);
 		return res;
 	}
+	mydev.data_adc1 = (u16)res;
 	res = sprintf(buf, "%d\n", res);
 	return res;
 }
@@ -356,6 +361,7 @@ static ssize_t lux_show(struct class *class,
 		pr_err("tsl2580: error %d reading lux\n", res);
 		return res;
 	}
+	mydev.data_lux = (u16)res;
 	res = sprintf(buf, "%d\n", res);
 	
 	return res;

--- a/tsl2580/tsl2580.c
+++ b/tsl2580/tsl2580.c
@@ -42,6 +42,10 @@
 #define ODFN_B5C 0x0000 /* 0.00 * 2 ^ LUX_SCALE */
 #define ODFN_M5C 0x0000 /* 0.00 * 2 ^ LUX_SCALE */
 
+/* Random threashold values for interrupt */
+#define INT_LOW_TH 500
+#define INT_HIGH_TH 10000
+
 static u64 read_threashold = HZ;
 
 struct tsl2580_dev {
@@ -331,7 +335,44 @@ static int __must_check tsl2580_default_config(struct tsl2580_dev *dev)
 	ret = i2c_smbus_write_byte(dev->client, TSL2580_ANALOG_GAIN_16X);
 	if (IS_ERR_VALUE(ret))
 		return ret;
-
+	/* Interrupt config */
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_INT_REG);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_INT_CTRL_LEVEL | TSL2580_INT_PRST_TH);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_INT_THLLOW_REG);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client, INT_LOW_TH & 0xFF);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_INT_THLHIGH_REG);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client, (INT_LOW_TH >> 8));
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_INT_THHLOW_REG);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client, (INT_HIGH_TH & 0xFF));
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_INT_THHHIGH_REG);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client, (INT_HIGH_TH >> 8));
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	
 	return 0;
 }
 

--- a/tsl2580/tsl2580.c
+++ b/tsl2580/tsl2580.c
@@ -1,0 +1,186 @@
+#include <linux/module.h>
+#include <linux/device.h>
+#include <linux/i2c.h>
+#include <linux/sysfs.h>
+#include <linux/string.h>
+
+#include "tsl2580_regs.h"
+
+#define TSL2580_CLASS_NAME "tsl2580"
+
+struct tsl2580_dev {
+	struct i2c_client *client;
+};
+
+static struct tsl2580_dev mydev;
+static struct class *tsl2580_class;
+
+static ssize_t who_am_i_show(struct class *class, struct class_attribute *attr, char *buf);
+static int tsl2580_probe(struct i2c_client *client, const struct i2c_device_id *id);
+static int tsl2580_remove(struct i2c_client *client);
+
+static const struct i2c_device_id tsl2580_i2c_id[] = {
+	{"tsl2580", 0},
+	{},
+};
+MODULE_DEVICE_TABLE(i2c, tsl2580_i2c_id);
+
+static const struct of_device_id tsl2580_of_id[] = {
+	{.compatible = "gl,tsl2580"},
+	{},
+};
+MODULE_DEVICE_TABLE(of, tsl2580_of_id);
+
+static struct i2c_driver tsl2580_i2c_driver = {
+	.driver = {
+		.name = "tsl2580",
+		.of_match_table = tsl2580_of_id,
+		.owner = THIS_MODULE,
+	},
+	.probe = tsl2580_probe,
+	.remove = tsl2580_remove,
+	.id_table = tsl2580_i2c_id,
+};
+
+static struct class_attribute class_attr_who_am_i =
+				__ATTR(who_am_i, 00644, who_am_i_show, NULL);
+
+static int __must_check tsl2580_default_config(struct tsl2580_dev *dev)
+{
+	int ret;
+
+	if (!dev->client)
+		return -EINVAL;
+	ret = i2c_smbus_write_byte(dev->client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_CTRL_REG);
+	if (ret < 0)
+		return ret;
+	/* Enable TSL2580 */
+	ret = i2c_smbus_write_byte(dev->client, TSL2580_CTRL_POWER | TSL2580_CTRL_ADC_EN);
+	if (ret < 0)
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_TIMING_REG);
+	if (ret < 0)
+		return ret;
+	/* 148 integration cycles by default */
+	ret = i2c_smbus_write_byte(dev->client, TSL2580_TIMING_148);
+	if (ret < 0)
+		return ret;
+	ret = i2c_smbus_write_byte(dev->client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ANALOG_REG);
+	if (ret < 0)
+		return ret;
+	/* 16x analog gain by default */
+	ret = i2c_smbus_write_byte(dev->client, TSL2580_ANALOG_GAIN_16X);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static int tsl2580_probe(struct i2c_client *client,
+			const struct i2c_device_id *device_id)
+{
+	int ret;
+	u8 id;
+
+	pr_info("tsl2580: i2c client address is 0x%X\n", client->addr);
+
+	mydev.client = client;
+	ret = i2c_smbus_write_byte(mydev.client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ID_REG);
+	if (ret < 0) {
+		pr_err("tsl2580: error %d occured writing to the device\n", ret);
+		return ret;
+	}
+	id = i2c_smbus_read_byte(mydev.client);
+	id &= 0xF0;
+	if (id != TSL2580_LOW_ID && id != TSL2581_LOW_ID) {
+		pr_warn("tsl2580: wrong device id\n");
+		return -EINVAL;
+	}
+	ret = tsl2580_default_config(&mydev);
+	if (ret < 0) {
+		pr_err("tsl2580: failed to configure the device\n");
+		return ret;
+	}
+	return 0;
+}
+
+static int tsl2580_remove(struct i2c_client *client)
+{
+	pr_info("tsl2580: remove\n");
+	return 0;
+}
+
+
+static ssize_t who_am_i_show(struct class *class, struct class_attribute *attr, char *buf)
+{
+	char *type;
+	u8 id;
+	s32 ret;
+
+	ret = i2c_smbus_write_byte(mydev.client, TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_ID_REG);
+	if (ret < 0) {
+		pr_err("tsl2580: error %d occured writing to the device\n", ret);
+		return ret;
+	}
+	
+	id = i2c_smbus_read_byte(mydev.client);
+	id &= 0xF0;
+	if (id == TSL2580_LOW_ID)
+		type = "2580\n";
+	else if (id == TSL2581_LOW_ID)
+		type = "2581\n";
+	else
+		type = "Unknow device type\n";
+	ret = sprintf(buf, type);
+
+	return ret;
+}
+
+static int __init tsl2580_init(void)
+{
+	int ret;
+
+	ret = i2c_add_driver(&tsl2580_i2c_driver);
+	if (ret < 0) {
+		pr_err("tsl2580: failed to add an i2c driver; error %d\n", ret);
+		return ret;
+	}
+	pr_info("tsl2580: i2c driver created\n");
+
+	tsl2580_class = class_create(THIS_MODULE, TSL2580_CLASS_NAME);
+	if (IS_ERR(tsl2580_class)) {
+		ret = PTR_ERR(tsl2580_class);
+		pr_err("tsl2580: failed to create a class; error %ld\n", PTR_ERR(tsl2580_class));
+		goto err;
+	}
+	
+	ret = class_create_file(tsl2580_class, &class_attr_who_am_i);
+	if (ret < 0) {
+		pr_err("tsl2580: failed to create a who_am_i class attribute; error %d\n", ret);
+		goto err;
+	}
+
+	pr_info("tsl2580: init succeded\n");
+
+	return 0;
+err:
+	class_remove_file(tsl2580_class, &class_attr_who_am_i);
+	class_destroy(tsl2580_class);
+	return ret;
+}
+
+static void __exit tsl2580_exit(void)
+{
+	pr_info("tsl2580: enter exit\n");
+	class_remove_file(tsl2580_class, &class_attr_who_am_i);
+	class_destroy(tsl2580_class);
+	i2c_del_driver(&tsl2580_i2c_driver);
+	pr_info("tsl2580: exit\n");
+}
+
+module_init(tsl2580_init);
+module_exit(tsl2580_exit);
+
+MODULE_AUTHOR("Andrii Revva <milaner.work@gmail.com>");
+MODULE_LICENSE("GPL v2");
+MODULE_DESCRIPTION("TSL2580 driver");

--- a/tsl2580/tsl2580.c
+++ b/tsl2580/tsl2580.c
@@ -17,10 +17,14 @@ static struct tsl2580_dev mydev;
 static struct class *tsl2580_class;
 
 static s32 tsl2580_read_adc0(struct tsl2580_dev *dev);
+static s32 tsl2580_read_adc1(struct tsl2580_dev *dev);
 static ssize_t who_am_i_show(struct class *class,
 			struct class_attribute *attr,
 			char *buf);
 static ssize_t adc0_show(struct class *class,
+			struct class_attribute *attr,
+			char *buf);
+static ssize_t adc1_show(struct class *class,
 			struct class_attribute *attr,
 			char *buf);
 static int tsl2580_probe(struct i2c_client *client,
@@ -54,6 +58,31 @@ static struct class_attribute class_attr_who_am_i =
 				__ATTR(who_am_i, 00644, who_am_i_show, NULL);
 static struct class_attribute class_attr_adc0 =
 				__ATTR(adc0, 00644, adc0_show, NULL);
+static struct class_attribute class_attr_adc1 =
+				__ATTR(adc1, 00644, adc1_show, NULL);
+
+static s32 tsl2580_read_adc1(struct tsl2580_dev *dev)
+{
+	s32 low, high;
+
+	low = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_DATA1LOW_REG);
+	if (low < 0)
+		return low;
+	low = i2c_smbus_read_byte(dev->client);
+	if (low < 0)
+		return low;
+	high = i2c_smbus_write_byte(dev->client,
+	TSL2580_CMD_REG | TSL2580_TRNS_BLOCK | TSL2580_DATA1HIGH_REG);
+	if (high < 0)
+		return low;
+	high = i2c_smbus_read_byte(dev->client);
+	if (high < 0)
+		return high;
+	/* FIXME: assumes little endian */
+	return (low | (high << 16));
+
+}
 
 static s32 tsl2580_read_adc0(struct tsl2580_dev *dev)
 {
@@ -191,6 +220,22 @@ static ssize_t adc0_show(struct class *class,
 	return res;
 }
 
+static ssize_t adc1_show(struct class *class,
+			struct class_attribute *attr,
+			char *buf)
+{
+	s32 res;
+
+	res = tsl2580_read_adc1(&mydev);
+	if (res < 0) {
+		pr_err("tsl2580: error %d reading adc0\n", res);
+		return res;
+	}
+	res = sprintf(buf, "%d\n", res);
+	return res;
+}
+
+
 
 static int __init tsl2580_init(void)
 {
@@ -218,8 +263,12 @@ static int __init tsl2580_init(void)
 	}
 	ret = class_create_file(tsl2580_class, &class_attr_adc0);
 	if (ret < 0) {
-		pr_err("tsl2580: error %d creating a adc0 attribute\n", ret);
+		pr_err("tsl2580: error %d creating an adc0 attribute\n", ret);
 		goto err;
+	}
+	ret = class_create_file(tsl2580_class, &class_attr_adc1);
+	if (ret < 0) {
+		pr_err("tsl2580: error %d creating an adc1 attribute\n", ret);
 	}
 
 	pr_info("tsl2580: init succeded\n");
@@ -228,6 +277,7 @@ static int __init tsl2580_init(void)
 err:
 	class_remove_file(tsl2580_class, &class_attr_who_am_i);
 	class_remove_file(tsl2580_class, &class_attr_adc0);
+	class_remove_file(tsl2580_class, &class_attr_adc1);
 	class_destroy(tsl2580_class);
 	return ret;
 }
@@ -237,6 +287,7 @@ static void __exit tsl2580_exit(void)
 	pr_info("tsl2580: enter exit\n");
 	class_remove_file(tsl2580_class, &class_attr_who_am_i);
 	class_remove_file(tsl2580_class, &class_attr_adc0);
+	class_remove_file(tsl2580_class, &class_attr_adc1);
 	class_destroy(tsl2580_class);
 	i2c_del_driver(&tsl2580_i2c_driver);
 	pr_info("tsl2580: exit\n");

--- a/tsl2580/tsl2580.dts
+++ b/tsl2580/tsl2580.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+
+	fragment@0 {
+		target = <&i2c1>;
+
+		__overlay__ {
+			#address-cells = < 1 >;
+			#size-cells = < 0 >;
+			tsl2580@39 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "gl,tsl2580";
+				status = "ok";
+				reg = <0x39>;
+			};
+		};
+	};
+
+};

--- a/tsl2580/tsl2580_regs.h
+++ b/tsl2580/tsl2580_regs.h
@@ -79,4 +79,9 @@
 #define TSL2580_INT_PRST_14 0x0E
 #define TSL2580_INT_PRST_15 0x0F
 
+/* Command register special function */
+#define TSL2580_CMD_INT_CLR 0x01
+#define TSL2580_CMD_STOP_MI 0x02
+#define TSL2580_CMD_START_MI 0x03
+
 #endif

--- a/tsl2580/tsl2580_regs.h
+++ b/tsl2580/tsl2580_regs.h
@@ -1,0 +1,55 @@
+#ifndef __TSL2580_REGS_H
+#define __TSL2580_REGS_H
+
+/* High 4 bits of device id */
+#define TSL2580_LOW_ID 0b10000000
+#define TSL2581_LOW_ID 0b10010000
+
+/* TSL2580 registers */
+#define TSL2580_CMD_REG 0x80
+#define TSL2580_CTRL_REG 0x00
+#define TSL2580_TIMING_REG 0x01
+#define TSL2580_INT_REG 0x02
+#define TSL2580_INT_THLLOW_REG 0x03
+#define TSL2580_INT_THLHIGH_REG 0x04
+#define TSL2580_INT_THHLOW_REG 0x05
+#define TSL2580_INT_THHHIGH_REG 0x06
+#define TSL2580_ANALOG_REG 0x07
+#define TSL2580_ID_REG 0x12
+#define TSL2580_CONSTANT_REG 0x13
+#define TSL2580_DATA0LOW_REG 0x14
+#define TSL2580_DATA0HIGH_REG 0x15
+#define TSL2580_DATA1LOW_REG 0x16
+#define TSL2580_DATA1HIGH_REG 0x17
+#define TSL2580_TIMERLOW_REG 0x18
+#define TSL2580_TIMERHIGH_REG 0x19
+
+/* Type of transactions */
+#define TSL2580_TRNS_BYTE 0x00
+#define TSL2580_TRNS_WORD 0x20
+#define TSL2580_TRNS_BLOCK 0x40
+#define TSL2580_TRNS_SPECIAL 0x60
+
+/* Control register commands */
+#define TSL2580_CTRL_POWER 0x1
+#define TSL2580_CTRL_ADC_EN 0x2
+#define TSL2580_CTRL_ADC_VALID 0x10
+#define TSL2580_CTRL_ADC_INTR 0x20
+
+/* Timing register integration cycles (must be in 2's complement) */
+#define TSL2580_TIMING_MANUAL 0
+#define TSL2580_TIMING_1 (u8)(~(1) + 1)
+#define TSL2580_TIMING_2 (u8)(~(2) + 1)
+#define TSL2580_TIMING_19 (u8)(~(19) + 1)
+#define TSL2580_TIMING_37 (u8)(~(37) + 1)
+#define TSL2580_TIMING_74 (u8)(~(74) + 1)
+#define TSL2580_TIMING_148 (u8)(~(148) + 1)
+#define TSL2580_TIMING_255 (u8)(~(255) + 1)
+
+/* Analog register gain options */
+#define TSL2580_ANALOG_GAIN_1X 0x0
+#define TSL2580_ANALOG_GAIN_2X 0x1
+#define TSL2580_ANALOG_GAIN_16X 0x2
+#define TSL2580_ANALOG_GAIN_111X 0x3
+
+#endif

--- a/tsl2580/tsl2580_regs.h
+++ b/tsl2580/tsl2580_regs.h
@@ -52,4 +52,31 @@
 #define TSL2580_ANALOG_GAIN_16X 0x2
 #define TSL2580_ANALOG_GAIN_111X 0x3
 
+/* Interrupt register control select */
+#define TSL2580_INT_CTRL_DISABLE 0x00
+#define TSL2580_INT_CTRL_LEVEL (0b01 << 4)
+#define TSL2580_INT_CTRL_SMB (0b10 << 4)
+#define TSL2580_INT_CTRL_TEST (0b11 << 4)
+
+/* Interrupt register stop ADC integration on interrupt */
+#define TSL2580_INT_CTRL_INTR_STOP 1 << 6
+
+/* Interrupt register persistance select */
+#define TSL2580_INT_PRST_ADC 0x00
+#define TSL2580_INT_PRST_THL 0x01
+#define TSL2580_INT_PRST_2 0x02
+#define TSL2580_INT_PRST_3 0x03
+#define TSL2580_INT_PRST_4 0x04
+#define TSL2580_INT_PRST_5 0x05
+#define TSL2580_INT_PRST_6 0x06
+#define TSL2580_INT_PRST_7 0x07
+#define TSL2580_INT_PRST_8 0x08
+#define TSL2580_INT_PRST_9 0x09
+#define TSL2580_INT_PRST_10 0x0A
+#define TSL2580_INT_PRST_11 0x0B
+#define TSL2580_INT_PRST_12 0x0C
+#define TSL2580_INT_PRST_13 0x0D
+#define TSL2580_INT_PRST_14 0x0E
+#define TSL2580_INT_PRST_15 0x0F
+
 #endif

--- a/tsl2580/tsl2580_regs.h
+++ b/tsl2580/tsl2580_regs.h
@@ -48,7 +48,7 @@
 
 /* Analog register gain options */
 #define TSL2580_ANALOG_GAIN_1X 0x0
-#define TSL2580_ANALOG_GAIN_2X 0x1
+#define TSL2580_ANALOG_GAIN_8X 0x1
 #define TSL2580_ANALOG_GAIN_16X 0x2
 #define TSL2580_ANALOG_GAIN_111X 0x3
 

--- a/tsl2580/tsl2580_regs.h
+++ b/tsl2580/tsl2580_regs.h
@@ -63,7 +63,7 @@
 
 /* Interrupt register persistance select */
 #define TSL2580_INT_PRST_ADC 0x00
-#define TSL2580_INT_PRST_THL 0x01
+#define TSL2580_INT_PRST_TH 0x01
 #define TSL2580_INT_PRST_2 0x02
 #define TSL2580_INT_PRST_3 0x03
 #define TSL2580_INT_PRST_4 0x04


### PR DESCRIPTION
This is a solution for the sixth homework.
The GPIO pin is hard coded, and is not instantiated in dt. The driver uses deprecated gpio interface (linux/gpio.h).
Other information can be found in commit messages.