### PR TITLE
Homework4 : memory(userspace)

### DIFF
--- a/memory/mem.c
+++ b/memory/mem.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <malloc.h>
+#include <math.h>
+#include <alloca.h>
+#include <time.h>
+
+unsigned long long rdtsc()
+{
+	unsigned int lo, hi;
+	asm volatile("rdtsc\n" : "=a"(lo), "=d"(hi));
+	return ((unsigned long long)hi << 32) | lo;
+}
+
+
+int main()
+{
+	return 0;
+}

--- a/memory/mem.c
+++ b/memory/mem.c
@@ -58,9 +58,31 @@ int tryCalloc()
 	return 0;
 }
 
+int tryAlloca()
+{
+	static int npow;
+	int *pointer;
+	size_t size = pow(2.0, (double)npow++);
+
+	//printf("Trying to alloc at %d\n", npow);
+
+	ticks = rdtsc();
+	pointer = (int *)alloca(size);
+	ticks = rdtsc() - ticks;
+
+	printf("Alloca %ld bytes lasts %d ticks\n", size, ticks);
+	// alloca never return NULL
+	// lets try crash the program
+
+	*(pointer + size) = 0x1;
+
+	return 0;
+}
+
 int main()
 {
     while (!tryMalloc());
     while (!tryCalloc());
+    while (!tryAlloca());
 	return 0;
 }

--- a/memory/mem.c
+++ b/memory/mem.c
@@ -36,8 +36,31 @@ int tryMalloc()
 	return 0;
 }
 
+int tryCalloc()
+{
+	static int npow;
+	void *pointer;
+	size_t size = pow(2.0, (double)npow++);
+
+	ticks = rdtsc();
+	pointer = (void *)calloc(1, size);
+	ticks = rdtsc() - ticks;
+
+	printf("Calloc %ld bytes lasts %d ticks\n", size, ticks);
+
+	if (pointer == NULL) {
+		printf("Bad calloc at %ld\n", size);
+		return -1;
+	}
+
+	free(pointer);
+
+	return 0;
+}
+
 int main()
 {
     while (!tryMalloc());
+    while (!tryCalloc());
 	return 0;
 }

--- a/memory/mem.c
+++ b/memory/mem.c
@@ -4,6 +4,9 @@
 #include <alloca.h>
 #include <time.h>
 
+
+unsigned long long ticks;
+
 unsigned long long rdtsc()
 {
 	unsigned int lo, hi;
@@ -11,8 +14,30 @@ unsigned long long rdtsc()
 	return ((unsigned long long)hi << 32) | lo;
 }
 
+int tryMalloc()
+{
+	static int npow;
+	void *pointer;
+	size_t size = pow(2.0, (double)npow++);
+
+	ticks = rdtsc();
+	pointer = (void *)malloc(size);
+	ticks = rdtsc() - ticks;
+
+	printf("Malloc %ld byte lasts %d ticks\n", size, ticks);
+
+	if (pointer == NULL) {
+		printf("Bad malloc at %ld\n", size);
+		return -1;
+	}
+
+	free(pointer);
+
+	return 0;
+}
 
 int main()
 {
+    while (!tryMalloc());
 	return 0;
 }


### PR DESCRIPTION
### Description
Program tries to allocate buffers with sizes 2^x for x in range from 0 to maximum possible value using functions: malloc, calloc, alloca. Also it measures time of each allocation.

### Example

```
./mem
Malloc 1 byte lasts 110180 ticks
Malloc 2 byte lasts 120 ticks
Malloc 4 byte lasts 80 ticks
Malloc 8 byte lasts 60 ticks
Malloc 16 byte lasts 200 ticks
Malloc 32 byte lasts 340 ticks
Malloc 64 byte lasts 300 ticks
Malloc 128 byte lasts 340 ticks
Malloc 256 byte lasts 300 ticks
Malloc 512 byte lasts 300 ticks
Malloc 1024 byte lasts 320 ticks
Malloc 2048 byte lasts 4660 ticks
Malloc 4096 byte lasts 320 ticks
Malloc 8192 byte lasts 3940 ticks
Malloc 16384 byte lasts 3680 ticks
Malloc 32768 byte lasts 4060 ticks
Malloc 65536 byte lasts 3720 ticks
Malloc 131072 byte lasts 3360 ticks
Malloc 262144 byte lasts 8740 ticks
Malloc 524288 byte lasts 5560 ticks
Malloc 1048576 byte lasts 5120 ticks
Malloc 2097152 byte lasts 8040 ticks
Malloc 4194304 byte lasts 7080 ticks
Malloc 8388608 byte lasts 29160 ticks
Malloc 16777216 byte lasts 9920 ticks
Malloc 33554432 byte lasts 9280 ticks
Malloc 67108864 byte lasts 6860 ticks
Malloc 134217728 byte lasts 6180 ticks
Malloc 268435456 byte lasts 6100 ticks
Malloc 536870912 byte lasts 7300 ticks
Malloc 1073741824 byte lasts 6860 ticks
Malloc 2147483648 byte lasts 6860 ticks
Malloc 4294967296 byte lasts 6820 ticks
Malloc 8589934592 byte lasts 6920 ticks
Malloc 17179869184 byte lasts 5700 ticks
Bad malloc at 17179869184
Calloc 1 bytes lasts 720 ticks
Calloc 2 bytes lasts 180 ticks
Calloc 4 bytes lasts 220 ticks
Calloc 8 bytes lasts 220 ticks
Calloc 16 bytes lasts 300 ticks
Calloc 32 bytes lasts 360 ticks
Calloc 64 bytes lasts 340 ticks
Calloc 128 bytes lasts 6880 ticks
Calloc 256 bytes lasts 380 ticks
Calloc 512 bytes lasts 440 ticks
Calloc 1024 bytes lasts 580 ticks
Calloc 2048 bytes lasts 580 ticks
Calloc 4096 bytes lasts 900 ticks
Calloc 8192 bytes lasts 5600 ticks
Calloc 16384 bytes lasts 5380 ticks
Calloc 32768 bytes lasts 12760 ticks
Calloc 65536 bytes lasts 26720 ticks
Calloc 131072 bytes lasts 63000 ticks
Calloc 262144 bytes lasts 125120 ticks
Calloc 524288 bytes lasts 36580 ticks
Calloc 1048576 bytes lasts 365340 ticks
Calloc 2097152 bytes lasts 546840 ticks
Calloc 4194304 bytes lasts 1012920 ticks
Calloc 8388608 bytes lasts 2032820 ticks
Calloc 16777216 bytes lasts 4949420 ticks
Calloc 33554432 bytes lasts 34580 ticks
Calloc 67108864 bytes lasts 7000 ticks
Calloc 134217728 bytes lasts 6900 ticks
Calloc 268435456 bytes lasts 7300 ticks
Calloc 536870912 bytes lasts 9040 ticks
Calloc 1073741824 bytes lasts 7380 ticks
Calloc 2147483648 bytes lasts 6940 ticks
Calloc 4294967296 bytes lasts 7240 ticks
Calloc 8589934592 bytes lasts 7260 ticks
Calloc 17179869184 bytes lasts 7060 ticks
Bad calloc at 17179869184
Alloca 1 bytes lasts 40 ticks
Alloca 2 bytes lasts 40 ticks
Alloca 4 bytes lasts 40 ticks
Alloca 8 bytes lasts 200 ticks
Alloca 16 bytes lasts 180 ticks
Alloca 32 bytes lasts 180 ticks
Alloca 64 bytes lasts 180 ticks
Alloca 128 bytes lasts 180 ticks
Alloca 256 bytes lasts 180 ticks
Alloca 512 bytes lasts 180 ticks
Alloca 1024 bytes lasts 200 ticks
Alloca 2048 bytes lasts 180 ticks
Alloca 4096 bytes lasts 180 ticks
Segmentation fault (core dumped)

```